### PR TITLE
stanford-mods is a dependency on mods_display and should be required when loading mods-display

### DIFF
--- a/lib/mods_display.rb
+++ b/lib/mods_display.rb
@@ -39,6 +39,8 @@ require "mods_display/fields/sub_title"
 require "mods_display/fields/title"
 require "mods_display/fields/values"
 
+require 'stanford-mods'
+
 require "i18n"
 require "i18n/backend/fallbacks" 
 I18n::Backend::Simple.send(:include, I18n::Backend::Fallbacks)


### PR DESCRIPTION
@jkeck This should fix https://github.com/sul-dlss/mods_display_app/blob/master/mods_display_model.rb#L2
