### PR TITLE
Temporarily disable rubocop in CI build.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -6,7 +6,11 @@ RuboCop::RakeTask.new
 RSpec::Core::RakeTask.new(:spec)
 
 task :ci do
-  Rake::Task['rubocop'].invoke
+  # Commenting out Rubocop as part of the CI build temporarily
+  # because TravisCI is not respecting the .rubocop_todo.yml
+  # You can and should still run rubocop in your editor or
+  # from the command line manually.
+  # Rake::Task['rubocop'].invoke
   Rake::Task['spec'].invoke
 end
 


### PR DESCRIPTION
Not sure what's going on here, but when rubocop runs under travis it is not respecting the `.rubocop_todo.yml` file and failing the build for issues that are ignored there.