### PR TITLE
For HTML rendering, converts Contents into <li> list using "--" as delimiter

### DIFF
--- a/lib/mods_display/fields/contents.rb
+++ b/lib/mods_display/fields/contents.rb
@@ -1,5 +1,23 @@
 module ModsDisplay
   class Contents < Field
+    def to_html
+      return nil if fields.empty? || @config.ignore?
+      output = ''
+      fields.each do |field|
+        next unless field.values.any? { |f| f && !f.empty? }
+        output << "<dt#{label_class} #{sanitized_field_title(field.label)}>#{field.label}</dt>"
+        output << "<dd#{value_class}>"
+        output << '<ul><li>'
+        # compress all values into a "--"-delimited string then split them up
+        output << field.values.join('--').split('--').map(&:strip).map do |val|
+          @config.link ? link_to_value(val.to_s) : link_urls_and_email(val.to_s)
+        end.join('</li><li>')
+        output << '</li></ul>'
+        output << '</dd>'
+      end
+      output
+    end
+
     private
 
     def displayLabel(element)

--- a/spec/fields/contents_spec.rb
+++ b/spec/fields/contents_spec.rb
@@ -21,4 +21,19 @@ describe ModsDisplay::Contents do
       expect(mods_display_contents(@display_label).label).to eq('Special Label:')
     end
   end
+  context 'multi-valued contents' do
+    let(:toc) do
+      Stanford::Mods::Record.new.from_str(
+              '<mods><tableOfContents>Content Note 1 -- Content Note 2</tableOfContents></mods>', false
+            ).tableOfContents
+    end
+    it 'should have one value with "--" marker' do
+      mdc = mods_display_contents(toc)
+      expect(mdc.fields.first.values).to eq ['Content Note 1 -- Content Note 2']
+    end
+    it 'should render as a list' do
+      html = mods_display_contents(toc).to_html
+      expect(html).to include '<dd><ul><li>Content Note 1</li><li>Content Note 2</li></ul></dd>'
+    end
+  end
 end


### PR DESCRIPTION
This PR is connected to https://github.com/sul-dlss/exhibits/issues/910. It overrides the `to_html` method in the `Contents` field to render the HTML as a `<ul>` list.

### Before

![screen shot 2017-11-21 at 10 45 47 am](https://user-images.githubusercontent.com/1861171/33094288-7a1a94b0-ceb4-11e7-81cc-fc78900e5511.png)


### After

![screen shot 2017-11-21 at 11 56 47 am](https://user-images.githubusercontent.com/1861171/33094291-7e3dac08-ceb4-11e7-88a6-fc5299374890.png)
