### PR TITLE
update ruby versions for Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 notifications:
   email: false
 rvm:
-  - 2.3.1
-  - 2.2.3
-  - 2.1.7
+  - 2.4.1
+  - 2.3.4
+  - 2.2.8


### PR DESCRIPTION
- added 2.4.x
- dropped 2.1.x
- updated 2.2.x and 2.3.x