### PR TITLE
[WIP] use roleTerm (code or text) as the display label and remove role after name

### DIFF
--- a/lib/mods_display/fields/name.rb
+++ b/lib/mods_display/fields/name.rb
@@ -10,7 +10,7 @@ module ModsDisplay
         elsif !name_parts(value).empty?
           person = ModsDisplay::Name::Person.new(name: name_parts(value), roles: roles)
         end
-        ModsDisplay::Values.new(label: displayLabel(value) || name_label(value), values: [person]) if person
+        ModsDisplay::Values.new(label: displayLabel(value) || role_label(value) || name_label(value), values: [person]) if person
       end.compact
       collapse_fields(return_fields)
     end
@@ -43,6 +43,13 @@ module ModsDisplay
       else
         I18n.t('mods_display.contributor')
       end
+    end
+
+    def role_label(element)
+      return unless element.role.present? && element.role.roleTerm.present?
+      element.role.roleTerm.collect do |role|
+        relator_codes[role.text.downcase] || role.text.capitalize
+      end.join(', ')
     end
 
     def role?(element)

--- a/spec/fields/name_spec.rb
+++ b/spec/fields/name_spec.rb
@@ -36,10 +36,10 @@ describe ModsDisplay::Language do
       expect(mods_display_name(@name).fields.first.label).to eq('Author/Creator:')
     end
     it "should label 'Author/Creator' for primary authors" do
-      expect(mods_display_name(@primary_name).fields.first.label).to eq('Author/Creator:')
+      expect(mods_display_name(@primary_name).fields.first.label).to eq('Lithographer')
     end
     it 'should apply contributor labeling to all non blank/author/creator roles' do
-      expect(mods_display_name(@contributor).fields.first.label).to eq('Contributor:')
+      expect(mods_display_name(@contributor).fields.first.label).to eq('Lithographer')
     end
   end
 
@@ -84,7 +84,7 @@ describe ModsDisplay::Language do
       expect(fields.first.values.length).to eq(1)
       expect(fields.first.values.first.to_s).to eq('John Doe')
 
-      expect(fields[1].label).to eq('Contributor:')
+      expect(fields[1].label).to eq('Lithographer')
       expect(fields[1].values.length).to eq(1)
       expect(fields[1].values.first.name).to eq('Jane Doe')
       expect(fields[1].values.first.roles).to eq(['lithographer'])
@@ -99,6 +99,7 @@ describe ModsDisplay::Language do
       it 'should get the role when present' do
         fields = mods_display_name(@name_with_role).fields
         expect(fields.length).to eq(1)
+        expect(fields.first.label).to eq('Depicted')
         expect(fields.first.values.length).to eq(1)
         expect(fields.first.values.first).to be_a(ModsDisplay::Name::Person)
         expect(fields.first.values.first.roles).to eq(['Depicted'])
@@ -106,30 +107,35 @@ describe ModsDisplay::Language do
       it 'should decode encoded roleTerms when no text (or non-typed) roleTerm is available' do
         fields = mods_display_name(@encoded_role).fields
         expect(fields.length).to eq(1)
+        expect(fields.first.label).to eq('Lithographer')
         expect(fields.first.values.length).to eq(1)
         expect(fields.first.values.first.to_s).to eq('John Doe (Lithographer)')
       end
       it "should get the type='text' role before an untyped role" do
         fields = mods_display_name(@mixed_role).fields
         expect(fields.length).to eq(1)
+        expect(fields.first.label).to eq('Publisher, Engraver')
         expect(fields.first.values.length).to eq(1)
         expect(fields.first.values.first.roles).to eq(['engraver'])
       end
       it 'should be handled correctly when there are more than one' do
         fields = mods_display_name(@multiple_roles).fields
         expect(fields.length).to eq(1)
+        expect(fields.first.label).to eq('Depicted, Artist')
         expect(fields.first.values.length).to eq(1)
         expect(fields.first.values.first.roles).to eq(%w(Depicted Artist))
       end
       it 'should handle code and text roleTerms together correctly' do
         fields = mods_display_name(@complex_roles).fields
         expect(fields.length).to eq(1)
+        expect(fields.first.label).to eq('Depicted, Depositor')
         expect(fields.first.values.length).to eq(1)
         expect(fields.first.values.first.roles).to eq(['Depicted'])
       end
       it 'should comma seperate multiple roles' do
         fields = mods_display_name(@multiple_roles).fields
         expect(fields.length).to eq(1)
+        expect(fields.first.label).to eq('Depicted, Artist')
         expect(fields.first.values.length).to eq(1)
         expect(fields.first.values.first.to_s).to eq('John Doe (Depicted, Artist)')
       end


### PR DESCRIPTION
This PR is connected to https://github.com/sul-dlss/exhibits/issues/910 and https://github.com/sul-dlss/exhibits/issues/936

Marked **WIP**:
- [ ] update to new role display requirements (see 936)
- [ ] add further testing