### PR TITLE
use roleTerm (code or text) as the display label and remove role after name

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4,7 +4,7 @@ en:
     abstract: "Abstract:"
     access_condition: "Access condition:"
     alternative_title: "Alternative title:"
-    author_creator: "Author/Creator:"
+    associated_with: "Associated with:"
     bibliography: "Bibliography:"
     biographical_historical: "Biographical/Historical:"
     citation_reference: "Citation/Reference:"

--- a/lib/mods_display/fields/subject.rb
+++ b/lib/mods_display/fields/subject.rb
@@ -45,17 +45,13 @@ module ModsDisplay
             end
             if @config.link && @config.hierarchical_link
               if val.is_a?(ModsDisplay::Name::Person)
-                txt = link_to_value(val.name, buffer.join(' '))
-                txt << " (#{val.roles.join(', ')})" if val.roles
-                sub_parts << txt
+                sub_parts << link_to_value(val.name, buffer.join(' '))
               else
                 sub_parts << link_to_value(val, buffer.join(' '))
               end
             elsif @config.link
               if val.is_a?(ModsDisplay::Name::Person)
-                txt = link_to_value(val.name)
-                txt << " (#{val.roles.join(', ')})" if val.roles
-                sub_parts << txt
+                sub_parts << link_to_value(val.name)
               else
                 sub_parts << link_to_value(val.to_s)
               end

--- a/spec/fields/name_spec.rb
+++ b/spec/fields/name_spec.rb
@@ -19,6 +19,7 @@ describe ModsDisplay::Language do
     @name = Stanford::Mods::Record.new.from_str(simple_name_fixture, false).plain_name
     @blank_name = Stanford::Mods::Record.new.from_str(blank_name_fixture, false).plain_name
     @primary_name = Stanford::Mods::Record.new.from_str(primary_name_fixture, false).plain_name
+    @primary_name_solo = Stanford::Mods::Record.new.from_str(primary_name_solo_fixture, false).plain_name
     @contributor = Stanford::Mods::Record.new.from_str(contributor_fixture, false).plain_name
     @encoded_role = Stanford::Mods::Record.new.from_str(encoded_role_fixture, false).plain_name
     @mixed_role = Stanford::Mods::Record.new.from_str(mixed_role_fixture, false).plain_name
@@ -30,16 +31,27 @@ describe ModsDisplay::Language do
     @complex_roles = Stanford::Mods::Record.new.from_str(complex_role_name_fixture, false).plain_name
     @name_with_role = Stanford::Mods::Record.new.from_str(name_with_role_fixture, false).plain_name
     @multiple_roles = Stanford::Mods::Record.new.from_str(multiple_roles_fixture, false).plain_name
+    @author_role = Stanford::Mods::Record.new.from_str(author_role_fixture, false).plain_name
+    @many_roles_and_names = Stanford::Mods::Record.new.from_str(many_roles_and_names_fixture, false).plain_name
+    @names_with_code_and_text_roles = Stanford::Mods::Record.new.from_str(names_with_code_and_text_roles_fixture, false).plain_name
   end
+  let(:default_label) { 'Associated with:' }
+
   describe 'label' do
     it 'should default Author/Creator when no role is available' do
-      expect(mods_display_name(@name).fields.first.label).to eq('Author/Creator:')
+      expect(mods_display_name(@name).fields.first.label).to eq(default_label)
     end
-    it "should label 'Author/Creator' for primary authors" do
-      expect(mods_display_name(@primary_name).fields.first.label).to eq('Author/Creator:')
+    it "should label as role for primary authors with a role" do
+      expect(mods_display_name(@primary_name).fields.first.label).to eq('Lithographer:')
     end
-    it 'should apply contributor labeling to all non blank/author/creator roles' do
-      expect(mods_display_name(@contributor).fields.first.label).to eq('Contributor:')
+    it "should label 'Author/Creator' for non-role primary authors" do
+      expect(mods_display_name(@primary_name_solo).fields.first.label).to eq(default_label)
+    end
+    it 'should apply role labeling with text' do
+      expect(mods_display_name(@contributor).fields.first.label).to eq('Lithographer:')
+    end
+    it 'should apply role labeling with code' do
+      expect(mods_display_name(@author_role).fields.first.label).to eq('Author:')
     end
   end
 
@@ -71,7 +83,7 @@ describe ModsDisplay::Language do
     it 'should collapse adjacent matching labels' do
       fields = mods_display_name(@collapse_label).fields
       expect(fields.length).to eq(1)
-      expect(fields.first.label).to eq('Author/Creator:')
+      expect(fields.first.label).to eq(default_label)
       fields.first.values.each do |val|
         expect(['John Doe', 'Jane Doe']).to include val.to_s
       end
@@ -79,59 +91,64 @@ describe ModsDisplay::Language do
     it 'should perseve order and separation of non-adjesent matching labels' do
       fields = mods_display_name(@complex_labels).fields
 
-      expect(fields.length).to eq(3)
-      expect(fields.first.label).to eq('Author/Creator:')
-      expect(fields.first.values.length).to eq(1)
-      expect(fields.first.values.first.to_s).to eq('John Doe')
+      expect(fields.length).to eq(2)
+      expect(fields.first.label).to eq(default_label)
+      expect(fields.first.values.length).to eq(3)
+      expect(fields.first.values.map(&:to_s)).to include 'John Doe', 'Jane Dough', 'John Dough'
 
-      expect(fields[1].label).to eq('Contributor:')
+      expect(fields[1].label).to eq('Lithographer:')
       expect(fields[1].values.length).to eq(1)
       expect(fields[1].values.first.name).to eq('Jane Doe')
-      expect(fields[1].values.first.roles).to eq(['lithographer'])
-
-      expect(fields.last.label).to eq('Author/Creator:')
-      expect(fields.last.values.length).to eq(2)
-      fields.last.values.each do |val|
-        expect(['Jane Dough', 'John Dough']).to include val.to_s
-      end
     end
     describe 'roles' do
       it 'should get the role when present' do
         fields = mods_display_name(@name_with_role).fields
         expect(fields.length).to eq(1)
+        expect(fields.first.label).to eq('Depicted:')
         expect(fields.first.values.length).to eq(1)
         expect(fields.first.values.first).to be_a(ModsDisplay::Name::Person)
-        expect(fields.first.values.first.roles).to eq(['Depicted'])
       end
       it 'should decode encoded roleTerms when no text (or non-typed) roleTerm is available' do
         fields = mods_display_name(@encoded_role).fields
         expect(fields.length).to eq(1)
+        expect(fields.first.label).to eq('Lithographer:')
         expect(fields.first.values.length).to eq(1)
-        expect(fields.first.values.first.to_s).to eq('John Doe (Lithographer)')
+        expect(fields.first.values.first.to_s).to eq('John Doe')
       end
       it "should get the type='text' role before an untyped role" do
         fields = mods_display_name(@mixed_role).fields
-        expect(fields.length).to eq(1)
+        expect(fields.length).to eq(2)
+        expect(fields.first.label).to eq 'Publisher:'
+        expect(fields.last.label).to eq 'Engraver:'
         expect(fields.first.values.length).to eq(1)
-        expect(fields.first.values.first.roles).to eq(['engraver'])
+        expect(fields.last.values.length).to eq(1)
+        expect(fields.first.values.first.name).to eq fields.last.values.first.name
       end
       it 'should be handled correctly when there are more than one' do
         fields = mods_display_name(@multiple_roles).fields
-        expect(fields.length).to eq(1)
+        expect(fields.length).to eq 2
+        expect(fields.first.label).to eq 'Depicted:'
+        expect(fields.last.label).to eq 'Artist:'
         expect(fields.first.values.length).to eq(1)
-        expect(fields.first.values.first.roles).to eq(%w(Depicted Artist))
+        expect(fields.last.values.length).to eq(1)
+        expect(fields.first.values.first.name).to eq fields.last.values.first.name
       end
       it 'should handle code and text roleTerms together correctly' do
         fields = mods_display_name(@complex_roles).fields
-        expect(fields.length).to eq(1)
-        expect(fields.first.values.length).to eq(1)
-        expect(fields.first.values.first.roles).to eq(['Depicted'])
+        expect(fields.length).to eq 2
+        expect(fields.first.label).to eq 'Depicted:'
+        expect(fields.last.label).to eq 'Depositor:'
+        expect(fields.first.values.first.name).to eq fields.last.values.first.name
       end
-      it 'should comma seperate multiple roles' do
-        fields = mods_display_name(@multiple_roles).fields
-        expect(fields.length).to eq(1)
-        expect(fields.first.values.length).to eq(1)
-        expect(fields.first.values.first.to_s).to eq('John Doe (Depicted, Artist)')
+      it 'should handle consolidation of many roles and names' do
+        fields = mods_display_name(@many_roles_and_names).fields
+        expect(fields.length).to eq 6
+        expect(fields.map(&:label)).to eq %w[Associated\ with: Surveyor: Cartographer: Editor: Electrotyper: Lithographer:]
+      end
+      it 'should handle consolidation of names with both code and text roleTerms' do
+        fields = mods_display_name(@names_with_code_and_text_roles).fields
+        expect(fields.length).to eq 3
+        expect(fields.map(&:label)).to eq %w[Author: Printer: Donor:]
       end
     end
   end
@@ -139,11 +156,11 @@ describe ModsDisplay::Language do
   describe 'to_html' do
     it 'should add the role to the name in parens' do
       html = mods_display_name(@name_with_role).to_html
-      expect(html).to match(%r{<dd>John Doe \(Depicted\)</dd>})
+      expect(html).to match(%r{<dd>John Doe</dd>})
     end
-    it 'should linke the name and not the role if requested' do
+    it 'should link the name and not the role if requested' do
       html = mods_display_name_link(@name_with_role).to_html
-      expect(html).to match(%r{<dd><a href='.*\?John Doe'>John Doe</a> \(Depicted\)</dd>})
+      expect(html).to match(%r{<dd><a href='.*\?John Doe'>John Doe</a></dd>})
     end
   end
 end

--- a/spec/fields/subject_spec.rb
+++ b/spec/fields/subject_spec.rb
@@ -68,16 +68,15 @@ describe ModsDisplay::Subject do
       expect(fields.length).to eq(1)
       expect(fields.first.values.first.first).to be_a(ModsDisplay::Name::Person)
       expect(fields.first.values.first.first.name).to eq('John Doe')
-      expect(fields.first.values.first.first.roles).to eq(['Depicted'])
     end
     it 'should link the name (and not the role) correctly' do
       html = mods_display_subject(@name_subject).to_html
-      expect(html).to match(%r{<a href='.*\?John Doe'>John Doe</a> \(Depicted\)})
+      expect(html).to match(%r{<a href='.*\?John Doe'>John Doe</a>})
       expect(html).to match(%r{<a href='.*\?Anonymous People'>Anonymous People</a>})
     end
     it 'should linke the name (and not the role) correctly when linking hierarchicaly' do
       html = mods_display_hierarchical_subject(@name_subject).to_html
-      expect(html).to match(%r{<a href='.*\?John Doe'>John Doe</a> \(Depicted\)})
+      expect(html).to match(%r{<a href='.*\?John Doe'>John Doe</a>})
       expect(html).to match(%r{<a href='.*\?John Doe Anonymous People'>Anonymous People</a>})
     end
   end

--- a/spec/fixtures/name_fixtures.rb
+++ b/spec/fixtures/name_fixtures.rb
@@ -35,6 +35,16 @@ module NameFixtures
     XML
   end
 
+  def primary_name_solo_fixture
+    <<-XML
+      <mods>
+        <name usage='primary'>
+          <namePart>John Doe</namePart>
+        </name>
+      </mods>
+    XML
+  end
+
   def contributor_fixture
     <<-XML
       <mods>
@@ -188,6 +198,198 @@ module NameFixtures
           </role>
           <role>
             <roleTerm type='text'>Artist</roleTerm>
+          </role>
+        </name>
+      </mods>
+    XML
+  end
+  def author_role_fixture
+    <<-XML
+      <mods>
+        <name>
+          <namePart>John Doe</namePart>
+          <role>
+            <roleTerm type='code' authority='marcrelator'>aut</roleTerm>
+          </role>
+        </name>
+      </mods>
+    XML
+  end
+  def many_roles_and_names_fixture # from fs947tw3404
+    <<-XML
+      <mods>
+        <name type="corporate">
+          <namePart>United States Coast Survey</namePart>
+        </name>
+        <name type="personal">
+          <namePart>Lawson, J. S.</namePart>
+          <role>
+            <roleTerm type="text">surveyor.</roleTerm>
+          </role>
+        </name>
+        <name type="personal">
+          <namePart>Wilkes, Charles</namePart>
+          <namePart type="date">1798-1877</namePart>
+          <role>
+            <roleTerm type="text">cartographer.</roleTerm>
+          </role>
+        </name>
+        <name type="personal">
+          <namePart>Jones, John P. (John Percival)</namePart>
+          <namePart type="date">1829-1912</namePart>
+          <role>
+            <roleTerm type="text">cartographer.</roleTerm>
+          </role>
+        </name>
+        <name type="personal">
+          <namePart>Patterson, C. P. (Carlile Pollock)</namePart>
+          <namePart type="date">1816-1881</namePart>
+          <role>
+            <roleTerm type="text">cartographer.</roleTerm>
+          </role>
+        </name>
+        <name type="personal">
+          <namePart>Schott, C. A.</namePart>
+          <role>
+            <roleTerm type="text">editor.</roleTerm>
+          </role>
+        </name>
+        <name type="personal">
+          <namePart>Cutts, R. D. (Richard Dominicus)</namePart>
+          <namePart type="date">1817-1883</namePart>
+          <role>
+            <roleTerm type="text">surveyor.</roleTerm>
+          </role>
+        </name>
+        <name type="personal">
+          <namePart>Gilbert, J. J.</namePart>
+          <role>
+            <roleTerm type="text">surveyor.</roleTerm>
+          </role>
+        </name>
+        <name type="personal">
+          <namePart>Rockwell, Cleveland</namePart>
+          <namePart type="date">1837-1907</namePart>
+          <role>
+            <roleTerm type="text">surveyor.</roleTerm>
+          </role>
+        </name>
+        <name type="personal">
+          <namePart>Coffin, G. W.</namePart>
+          <role>
+            <roleTerm type="text">surveyor.</roleTerm>
+          </role>
+        </name>
+        <name type="personal">
+          <namePart>Cordell, E.</namePart>
+          <role>
+            <roleTerm type="text">surveyor.</roleTerm>
+          </role>
+        </name>
+        <name type="personal">
+          <namePart>Davidson, George</namePart>
+          <namePart type="date">1825-1911</namePart>
+          <role>
+            <roleTerm type="text">surveyor.</roleTerm>
+          </role>
+        </name>
+        <name type="personal">
+          <namePart>Eimbeck, W.</namePart>
+          <role>
+            <roleTerm type="text">surveyor.</roleTerm>
+          </role>
+        </name>
+        <name type="personal">
+          <namePart>Hilgard, J. E. (Julius Erasmus)</namePart>
+          <namePart type="date">1825-1891</namePart>
+          <role>
+            <roleTerm type="text">editor.</roleTerm>
+          </role>
+        </name>
+        <name type="personal">
+          <namePart>Bache, A. D. (Alexander Dallas)</namePart>
+          <namePart type="date">1806-1867</namePart>
+          <role>
+            <roleTerm type="text">surveyor.</roleTerm>
+          </role>
+        </name>
+        <name type="personal">
+          <namePart>Rodgers, A. F.</namePart>
+          <role>
+            <roleTerm type="text">surveyor.</roleTerm>
+          </role>
+        </name>
+        <name type="personal">
+          <namePart>Harrison, A. M. (Alexander Medina)</namePart>
+          <namePart type="date">1829-1881</namePart>
+          <role>
+            <roleTerm type="text">surveyor.</roleTerm>
+          </role>
+        </name>
+        <name type="personal">
+          <namePart>Alden, James</namePart>
+          <namePart type="date">1810-1877</namePart>
+          <role>
+            <roleTerm type="text">surveyor.</roleTerm>
+          </role>
+        </name>
+        <name type="personal">
+          <namePart>Mathiot, G.</namePart>
+          <role>
+            <roleTerm type="text">electrotyper.</roleTerm>
+          </role>
+        </name>
+        <name type="personal">
+          <namePart>Harrison, A. M. (Alexander Medina)</namePart>
+          <namePart type="date">1829-1881</namePart>
+          <role>
+            <roleTerm type="text">surveyor.</roleTerm>
+          </role>
+        </name>
+        <name type="corporate">
+          <namePart>U.S. Coast and Geodetic Survey</namePart>
+          <role>
+            <roleTerm type="text">surveyor.</roleTerm>
+          </role>
+        </name>
+        <name type="corporate">
+          <namePart>N.Y. Lithographing, Engraving & Printing Co</namePart>
+          <role>
+            <roleTerm type="text">lithographer.</roleTerm>
+          </role>
+        </name>
+      </mods>
+    XML
+  end
+  def names_with_code_and_text_roles_fixture # from vn199zb9806
+    <<-XML
+      <mods>
+        <name type="personal" usage="primary" authority="naf" authorityURI="http://id.loc.gov/authorities/names" valueURI="http://id.loc.gov/authorities/names/n78095825" nameTitleGroup="1">
+          <namePart>Johnson, Samuel, 1709-1784</namePart>
+          <role>
+            <roleTerm type="code" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators" valueURI="http://id.loc.gov/vocabulary/relators/aut">aut</roleTerm>
+            <roleTerm type="text" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators" valueURI="http://id.loc.gov/vocabulary/relators/aut">author</roleTerm>
+          </role>
+        </name>
+        <name type="personal" authority="naf" authorityURI="http://id.loc.gov/authorities/names" valueURI="http://id.loc.gov/authorities/names/n78095825">
+          <namePart>Johnson, Samuel, 1709-1784</namePart>
+          <role>
+            <roleTerm type="code" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators" valueURI="http://id.loc.gov/vocabulary/relators/prt">prt</roleTerm>
+            <roleTerm type="text" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators" valueURI="http://id.loc.gov/vocabulary/relators/prt">printer</roleTerm>
+          </role>
+        </name>
+        <name type="personal">
+          <namePart>Downing, Donn Faber</namePart>
+          <role>
+            <roleTerm type="code" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators" valueURI="http://id.loc.gov/vocabulary/relators/dnr">dnr</roleTerm>
+            <roleTerm type="text" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators" valueURI="http://id.loc.gov/vocabulary/relators/dnr">donor</roleTerm>
+          </role>
+        </name>
+        <name type="personal">
+          <namePart>Sanders, Letitia Leigh</namePart>
+          <role>
+            <roleTerm type="code" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators" valueURI="http://id.loc.gov/vocabulary/relators/dnr">dnr</roleTerm>
+            <roleTerm type="text" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators" valueURI="http://id.loc.gov/vocabulary/relators/dnr">donor</roleTerm>
           </role>
         </name>
       </mods>


### PR DESCRIPTION
This PR is connected to https://github.com/sul-dlss/exhibits/issues/936. It changes how roles are handled. See the screenshots below, and the algorithm defined in https://github.com/sul-dlss/exhibits/issues/936#issuecomment-346491869.

### Before (fs947tw3404)

![33148601-4e507f70-cf81-11e7-819c-bbe27a9f6457](https://user-images.githubusercontent.com/1861171/33294674-8c3f0a46-d386-11e7-8d1d-543332a4a39f.png)

### After (fs947tw3404)

![screen shot 2017-11-27 at 2 04 33 pm](https://user-images.githubusercontent.com/1861171/33292186-22b6380a-d37d-11e7-907d-3aa5771f36ec.png)

### After (vn199zb9806)

![screen shot 2017-11-27 at 3 03 04 pm](https://user-images.githubusercontent.com/1861171/33294148-24e5e1be-d384-11e7-9984-3e3750681aec.png)