### PR TITLE
Update license logic to use a known list of licenses (taken from PURL).

### DIFF
--- a/lib/mods_display/fields/access_condition.rb
+++ b/lib/mods_display/fields/access_condition.rb
@@ -1,5 +1,53 @@
 module ModsDisplay
   class AccessCondition < Field
+    LICENSES = {
+      'cc-none' => { desc: '' },
+      'cc-by' => {
+        link: 'http://creativecommons.org/licenses/by/3.0/',
+        desc: 'This work is licensed under a Creative Commons Attribution 3.0 Unported License'
+      },
+      'cc-by-sa' => {
+        link: 'http://creativecommons.org/licenses/by-sa/3.0/',
+        desc: 'This work is licensed under a Creative Commons Attribution-Share Alike 3.0 Unported License'
+      },
+      'cc-by-nd' => {
+        link: 'http://creativecommons.org/licenses/by-nd/3.0/',
+        desc: 'This work is licensed under a Creative Commons Attribution-No Derivative Works 3.0 Unported License'
+      },
+      'cc-by-nc' => {
+        link: 'http://creativecommons.org/licenses/by-nc/3.0/',
+        desc: 'This work is licensed under a Creative Commons Attribution-Noncommercial 3.0 Unported License'
+      },
+      'cc-by-nc-sa' => {
+        link: 'http://creativecommons.org/licenses/by-nc-sa/3.0/',
+        desc: 'This work is licensed under a Creative Commons Attribution-Noncommercial-Share Alike 3.0 Unported License'
+      },
+      'cc-by-nc-nd' => {
+        link: 'http://creativecommons.org/licenses/by-nc-nd/3.0/',
+        desc: 'This work is licensed under a Creative Commons Attribution-Noncommercial-No Derivative Works 3.0 Unported License'
+      },
+      'cc-pdm' => {
+        link: 'http://creativecommons.org/publicdomain/mark/1.0/',
+        desc: 'This work is in the public domain per Creative Commons Public Domain Mark 1.0'
+      },
+      'odc-odc-pddl' => {
+        link: 'http://opendatacommons.org/licenses/pddl/',
+        desc: 'This work is licensed under a Open Data Commons Public Domain Dedication and License (PDDL)'
+      },
+      'odc-pddl' => {
+        link: 'http://opendatacommons.org/licenses/pddl/',
+        desc: 'This work is licensed under a Open Data Commons Public Domain Dedication and License (PDDL)'
+      },
+      'odc-odc-by' => {
+        link: 'http://opendatacommons.org/licenses/by/',
+        desc: 'This work is licensed under a Open Data Commons Attribution License'
+      },
+      'odc-odc-odbl' => {
+        link: 'http://opendatacommons.org/licenses/odbl/',
+        desc: 'This work is licensed under a Open Data Commons Open Database License (ODbL)'
+      }
+    }.freeze
+
     def fields
       return_fields = @values.map do |value|
         ModsDisplay::Values.new(
@@ -28,26 +76,32 @@ module ModsDisplay
     end
 
     def license_statement(element)
-      element.text[/^(.*) (.*):(.*)$/]
-      output = "<div class='#{[Regexp.last_match(1), Regexp.last_match(2)].join('-').downcase}'>"
-      if license_link(Regexp.last_match(1), Regexp.last_match(2))
-        link = "<a href='#{license_link(Regexp.last_match(1), Regexp.last_match(2))}'>#{Regexp.last_match(3).strip}</a>"
-        output << link
-      else
-        output << Regexp.last_match(3).strip
-      end
+      matches = element.text.match(/^(?<code>.*) (?<type>.*):(?<description>.*)$/)
+      code = matches[:code].downcase
+      type = matches[:type].downcase
+      description = license_description(code, type) || matches[:description]
+      url = license_url(code, type)
+      output = "<div class='#{code}-#{type}'>"
+      output << if url
+                  "<a href='#{url}'>#{description}</a>"
+                else
+                  description
+                end
       output << '</div>'
     end
 
-    def license_code_urls
-      { 'cc'  => 'http://creativecommons.org/licenses/',
-        'odc' => 'http://opendatacommons.org/licenses/' }
+    def license_url(code, type)
+      key = "#{code}-#{type}"
+      return unless LICENSES.key?(key)
+
+      LICENSES[key][:link]
     end
 
-    def license_link(code, type)
-      code = code.downcase
-      return unless license_code_urls.key?(code)
-      "#{license_code_urls[code]}#{type.downcase}#{"/#{@config.cc_license_version}/" if code == 'cc'}"
+    def license_description(code, type)
+      key = "#{code}-#{type}"
+      return unless LICENSES.key?(key) && LICENSES[key][:desc]
+
+      LICENSES[key][:desc]
     end
 
     def access_label(element)

--- a/spec/fields/access_condition_spec.rb
+++ b/spec/fields/access_condition_spec.rb
@@ -8,14 +8,6 @@ def mods_display_access_condition(mods_record)
   )
 end
 
-def mods_display_versioned_access_condition(mods_record, version)
-  ModsDisplay::AccessCondition.new(
-    mods_record,
-    ModsDisplay::Configuration::AccessCondition.new { cc_license_version version },
-    double('controller')
-  )
-end
-
 def mods_display_non_ignore_access_condition(mods_record)
   ModsDisplay::AccessCondition.new(
     mods_record,
@@ -68,31 +60,19 @@ describe ModsDisplay::AccessCondition do
         expect(fields.first.values.length).to eq(1)
         expect(fields.first.values.first).to include("<a href='http://creativecommons.org/licenses/by-sa/3.0/'>")
         expect(fields.first.values.first).to include(
-          'This work is licensed under a Creative Commons Attribution-Noncommercial 3.0 Unported License'
+          'This work is licensed under a Creative Commons Attribution-Share Alike 3.0 Unported License'
         )
       end
       it 'should itentify and link OpenDataCommons licenses properly' do
         fields = mods_display_access_condition(@odc_license_note).fields
         expect(fields.length).to eq(1)
         expect(fields.first.values.length).to eq(1)
-        expect(fields.first.values.first).to include("<a href='http://opendatacommons.org/licenses/pddl'>")
+        expect(fields.first.values.first).to include("<a href='http://opendatacommons.org/licenses/pddl/'>")
         expect(fields.first.values.first).to include(
           'This work is licensed under a Open Data Commons Public Domain Dedication and License (PDDL)'
         )
       end
-      it 'should have a configurable version for CC licenses' do
-        fields = mods_display_versioned_access_condition(@cc_license_note, '4.0').fields
-        expect(fields.length).to eq(1)
-        expect(fields.first.values.length).to eq(1)
-        expect(fields.first.values.first).to include('http://creativecommons.org/licenses/by-sa/4.0/')
-        expect(fields.first.values.first).not_to include('http://creativecommons.org/licenses/by-sa/3.0/')
-      end
-      it 'should not apply configured version to NON-CC licenses' do
-        fields = mods_display_versioned_access_condition(@odc_license_note, '4.0').fields
-        expect(fields.length).to eq(1)
-        expect(fields.first.values.length).to eq(1)
-        expect(fields.first.values.first).not_to include('/4.0/')
-      end
+
       it 'should not attempt unknown license types' do
         fields = mods_display_access_condition(@no_link_license_note).fields
         expect(fields.length).to eq(1)


### PR DESCRIPTION
Closes #64 

This PR updates the approach that we take to handling licenses and puts it more in line w/ what PURL is doing (and PURL may be able to use this instead of its own custom implementation in the future).  This will use the configured text for the license instead of what is in the metadata (as PURL does) but falls back to the text in the metadata if the license isn't known.

## yb129fc1507 (before)
<img width="813" alt="yb129fc1507-before" src="https://user-images.githubusercontent.com/96776/62799310-52968380-ba95-11e9-8766-5de4d5231ec3.png">

## yb129fc1507 (after)
<img width="793" alt="yb129fc1507-after" src="https://user-images.githubusercontent.com/96776/62799309-51fded00-ba95-11e9-9758-354770a89754.png">

