### PR TITLE
Add support for Purl/SearchWorks ActionView helpers

### DIFF
--- a/lib/mods_display.rb
+++ b/lib/mods_display.rb
@@ -49,3 +49,14 @@ require 'i18n/backend/fallbacks'
 I18n::Backend::Simple.send(:include, I18n::Backend::Fallbacks)
 I18n.load_path += Dir["#{File.expand_path('../..', __FILE__)}/config/locales/*.yml"]
 I18n.backend.load_translations
+
+# load Rails/Railtie
+begin
+  require 'rails'
+rescue LoadError
+  #do nothing
+end
+
+if defined? ::Rails::Railtie
+  require 'mods_display/railtie'
+end

--- a/lib/mods_display/helpers/record_helper.rb
+++ b/lib/mods_display/helpers/record_helper.rb
@@ -1,0 +1,131 @@
+# frozen_string_literal: true
+
+module ModsDisplay
+  module Helpers
+    module RecordHelper
+      def display_content_field(field)
+        return unless field.respond_to?(:label, :values) && field.values.any?(&:present?)
+
+        display_content_label(field.label) + display_content_values(field.values)
+      end
+
+      def display_content_label(label)
+        content_tag :dt, label
+      end
+
+      def display_content_values(values)
+        values.map do |value|
+          content_tag :dd, value
+        end.join('').html_safe
+      end
+
+      def mods_display_label(label)
+        content_tag(:dt, label.delete(':')) + "\n".html_safe
+      end
+
+      def mods_display_content(values, delimiter = nil)
+        if delimiter
+          content_tag(:dd, values.map do |value|
+            link_urls_and_email(value) if value.present?
+          end.compact.join(delimiter).html_safe)
+        else
+          Array[values].flatten.map do |value|
+            content_tag(:dd, link_urls_and_email(value.to_s).html_safe) if value.present?
+          end.join.html_safe
+        end
+      end
+
+      def mods_record_field(field, delimiter = nil)
+        return unless field.respond_to?(:label, :values) && field.values.any?(&:present?)
+
+        mods_display_label(field.label) + mods_display_content(field.values, delimiter)
+      end
+
+      def mods_name_field(field, &block)
+        return unless field.respond_to?(:label, :values) && field.values.any?(&:present?)
+
+        mods_display_label(field.label) + mods_display_name(field.values, &block)
+      end
+
+      def mods_display_name(names, &block)
+        names.map do |name|
+          content_tag(:dd) do
+            block_given? ? yield(name.name) : name.name
+          end
+        end.join.html_safe
+      end
+
+      # We need this to remove the ending ":" from the role labels only in data from
+      # mods_display
+      def sanitize_mods_name_label(label)
+        label.sub(/:$/, '')
+      end
+
+      def mods_subject_field(subject, &block)
+        return unless subject.values.any?(&:present?)
+
+        fields = subject.values.map do |subject_line|
+          content_tag :dd, safe_join(link_mods_subjects(subject_line, &block), ' > ')
+        end
+
+        (mods_display_label(subject.label) + safe_join(fields))
+      end
+
+      def mods_genre_field(genre, &block)
+        return unless genre.values.any?(&:present?)
+
+        fields = genre.values.map do |genre_line|
+          content_tag :dd, link_mods_genres(genre_line, &block)
+        end
+
+        mods_display_label(genre.label) + safe_join(fields)
+      end
+
+      def link_mods_genres(genre, &block)
+        link_buffer = []
+        link_to_mods_subject(genre, link_buffer, &block)
+      end
+
+      def link_mods_subjects(subjects, &block)
+        link_buffer = []
+        linked_subjects = []
+        subjects.each do |subject|
+          if subject.present?
+            linked_subjects << link_to_mods_subject(subject, link_buffer, &block)
+          end
+        end
+        linked_subjects
+      end
+
+      def link_to_mods_subject(subject, buffer, &block)
+        subject_text = subject.respond_to?(:name) ? subject.name : subject
+        link = block_given? ? yield(subject_text, buffer) : subject_text
+        buffer << subject_text.strip
+        link << " (#{subject.roles.join(', ')})" if subject.respond_to?(:roles) && subject.roles.present?
+        link
+      end
+
+      # rubocop:disable Layout/LineLength
+      def link_urls_and_email(val)
+        val = val.dup
+        # http://daringfireball.net/2010/07/improved_regex_for_matching_urls
+        url = %r{(?i)\b(?:https?://|www\d{0,3}[.]|[a-z0-9.\-]+[.][a-z]{2,4}/)(?:[^\s()<>]+|\([^\s()<>]+|\([^\s()<>]+\)*\))+(?:\([^\s()<>]+|\([^\s()<>]+\)*\)|[^\s`!()\[\]{};:'".,<>?«»“”‘’])}i
+        # http://www.regular-expressions.info/email.html
+        email = %r{[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+(?:[A-Z]{2}|com|org|net|edu|gov|mil|biz|info|mobi|name|aero|asia|jobs|museum)\b}i
+        matches = [val.scan(url), val.scan(email)].flatten.uniq
+        unless val =~ /<a/ # we'll assume that linking has alraedy occured and we don't want to double link
+          matches.each do |match|
+            if match =~ email
+              val.gsub!(match, "<a href='mailto:#{match}'>#{match}</a>")
+            else
+              val.gsub!(match, "<a href='#{match}'>#{match}</a>")
+            end
+          end
+        end
+        val
+      end
+      # rubocop:enable Layout/LineLength
+
+    end
+  end
+end

--- a/lib/mods_display/railtie.rb
+++ b/lib/mods_display/railtie.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module ModsDisplay
+  class Railtie < ::Rails::Railtie
+    ActiveSupport.on_load :action_view do
+      require 'mods_display/helpers/record_helper'
+      ::ActionView::Base.send :include, ModsDisplay::Helpers::RecordHelper
+    end
+  end
+end

--- a/mods_display.gemspec
+++ b/mods_display.gemspec
@@ -22,7 +22,9 @@ Gem::Specification.new do |gem|
 
   gem.add_development_dependency 'rake'
   gem.add_development_dependency 'rspec', '~> 3.0'
+  gem.add_development_dependency 'rspec-rails'
   gem.add_development_dependency 'rubocop'
   gem.add_development_dependency 'capybara'
   gem.add_development_dependency 'byebug'
+  gem.add_development_dependency 'rails', '~> 6.0'
 end

--- a/spec/fake_app.rb
+++ b/spec/fake_app.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require 'action_controller/railtie'
+require 'action_view/railtie'
+
+class ModsDisplayTestApp < Rails::Application
+end
+
+Rails.application.routes.draw do
+  resources 'searches', only: :index
+end
+
+class ApplicationController < ActionController::Base; end
+class SearchesController < ApplicationController
+  def index; end
+end
+
+Object.const_set(:ApplicationHelper, Module.new)

--- a/spec/helpers/record_helper_spec.rb
+++ b/spec/helpers/record_helper_spec.rb
@@ -1,0 +1,241 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'byebug'
+
+describe ModsDisplay::Helpers::RecordHelper, type: :helper do
+  let(:empty_field) { OpenStruct.new(label: 'test', values: ['']) }
+
+  describe 'display_content_field' do
+    let(:values) { ['guitar (1)', 'solo cowbell, trombone (2)'] }
+    let(:content) { OpenStruct.new(label: 'Instrumentation', values: values) }
+
+    it 'should return dt with label and dd with values' do
+      expect(helper.display_content_field(content)).to have_css('dt', text: 'Instrumentation')
+      expect(helper.display_content_field(content)).to have_css('dd', count: 2)
+    end
+  end
+
+  describe 'display_content_label' do
+    it 'should return correct dt' do
+      expect(helper.display_content_label('test')).to have_css('dt', text: 'test')
+    end
+  end
+
+  describe 'display_content_values' do
+    let(:values) { ['guitar (1)', 'solo cowbell, trombone (2)'] }
+
+    it 'should return dds of values' do
+      expect(helper.display_content_values(values)).to have_css('dd', count: 2)
+      expect(helper.display_content_values(values)).to have_css('dd', text: 'guitar (1)')
+      expect(helper.display_content_values(values)).to have_css('dd', text: 'solo cowbell, trombone (2)')
+    end
+  end
+
+  describe 'mods_display_label' do
+    it 'should return correct label' do
+      expect(helper.mods_display_label('test:')).not_to have_content ':'
+      expect(helper.mods_display_label('test:')).to have_css('dt', text: 'test')
+    end
+  end
+
+  describe 'mods_display_content' do
+    it 'should return correct content' do
+      expect(helper.mods_display_content('hello, there')).to have_css('dd', text: 'hello, there')
+    end
+    it 'should return multiple dd elements when a multi-element array is passed' do
+      expect(helper.mods_display_content(%w(hello there))).to have_css('dd', count: 2)
+    end
+    it 'should handle nil values correctly' do
+      expect(helper.mods_display_content(['something', nil])).to have_css('dd', count: 1)
+    end
+  end
+
+  describe 'mods_record_field' do
+    let(:mods_field) { OpenStruct.new(label: 'test', values: ['hello, there']) }
+    let(:url_field) { OpenStruct.new(label: 'test', values: ['https://library.stanford.edu']) }
+    let(:multi_values) { double(label: 'test', values: %w(123 321)) }
+
+    it 'should return correct content' do
+      expect(helper.mods_record_field(mods_field)).to have_css('dt', text: 'test')
+      expect(helper.mods_record_field(mods_field)).to have_css('dd', text: 'hello, there')
+    end
+    it 'should link fields with URLs' do
+      expect(mods_record_field(url_field)).to have_css("a[href='https://library.stanford.edu']", text: 'https://library.stanford.edu')
+    end
+    it 'should not print empty labels' do
+      expect(helper.mods_record_field(empty_field)).not_to be_present
+    end
+    it 'should join values with a <dd> by default' do
+      expect(helper.mods_record_field(multi_values)).to have_css('dd', count: 2)
+    end
+    it 'should join values with a supplied delimiter' do
+      expect(helper.mods_record_field(multi_values, 'DELIM')).to have_css('dd', count: 1)
+      expect(helper.mods_record_field(multi_values, 'DELIM')).to have_css('dd', text: '123DELIM321')
+    end
+  end
+
+  describe 'names' do
+    let(:name_field) do
+      OpenStruct.new(
+        label: 'Contributor',
+        values: [
+          OpenStruct.new(name: 'Winefrey, Oprah', roles: %w(Host Producer)),
+          OpenStruct.new(name: 'Kittenz, Emergency')
+        ]
+      )
+    end
+
+    describe '#mods_name_field' do
+      it 'should join the label and values' do
+        name = mods_name_field(name_field) do |name|
+          link_to(name, searches_path(q: "\"#{name}\"", search_field: 'search_author'))
+        end
+        expect(name).to match /<dt>Contributor<\/dt>/
+        expect(name).to match /<dd><a href.*<\/dd>/
+      end
+      it 'should not print empty labels' do
+        expect(mods_name_field(empty_field)).not_to be_present
+      end
+    end
+
+    describe '#mods_display_name' do
+      let(:name) do
+        mods_display_name(name_field.values) do |name|
+          link_to(name, searches_path(q: "\"#{name}\"", search_field: 'search_author'))
+        end
+      end
+
+      it 'should link to the name' do
+        expect(name).to match /<a href=.*%22Winefrey%2C\+Oprah%22.*>Winefrey, Oprah<\/a>/
+        expect(name).to match /<a href=.*%22Kittenz%2C\+Emergency%22.*>Kittenz, Emergency<\/a>/
+      end
+      it 'should link to an author search' do
+        expect(name).to match /<a href.*search_field=search_author.*>/
+      end
+    end
+
+    describe '#sanitize_mods_name_label' do
+      it 'removes a ":" at the end of label if present' do
+        expect(sanitize_mods_name_label('Test String:')).to eq 'Test String'
+        expect(sanitize_mods_name_label('Test String')).to eq 'Test String'
+      end
+    end
+  end
+
+  describe 'subjects' do
+    let(:subjects) { [OpenStruct.new(label: 'Subjects', values: [%w(Subject1a Subject1b), %w(Subject2a Subject2b Subject2c)])] }
+    let(:name_subjects) { [OpenStruct.new(label: 'Subjects', values: [OpenStruct.new(name: 'Person Name', roles: %w(Role1 Role2))])] }
+    let(:genres) { [OpenStruct.new(label: 'Genres', values: %w(Genre1 Genre2 Genre3))] }
+
+    describe '#mods_subject_field' do
+      let(:subject) do
+        mods_subject_field(subjects.first) do |subject_text|
+          link_to(
+            subject_text,
+            searches_path(
+              q: "\"#{[[], subject_text.strip].flatten.join(' ')}\"",
+              search_field: 'subject_terms'
+            )
+          )
+        end
+      end
+      it 'should join the subject fields in a dd' do
+        expect(subject).to match /<dd><a href=*.*\">Subject1a*.*Subject1b<\/a><\/dd><dd><a/
+      end
+      it "should join the individual subjects with a '>'" do
+        expect(subject).to match /Subject2b<\/a> &gt; <a href/
+      end
+      it 'should not print empty labels' do
+        expect(mods_subject_field(empty_field)).not_to be_present
+      end
+    end
+
+    describe '#mods_genre_field' do
+      it 'should join the genre fields with a dd' do
+        expect(mods_genre_field(genres.first) do |text|
+          link_to(text, searches_path(q: text))
+        end).to match /<dd><a href=*.*>Genre1*.*<\/a><\/dd><dd><a*.*Genre2<\/a><\/dd>/
+      end
+      it 'should not print empty labels' do
+        expect(mods_genre_field(empty_field)).not_to be_present
+      end
+    end
+
+    describe '#link_mods_subjects' do
+      let(:linked_subjects) do
+        link_mods_subjects(subjects.first.values.last) do |subject_text, buffer|
+          link_to(
+            subject_text,
+            searches_path(
+              q: "\"#{[buffer, subject_text.strip].flatten.join(' ')}\"",
+              search_field: 'subject_terms'
+            )
+          )
+        end
+      end
+
+      it 'should return all subjects' do
+        expect(linked_subjects.length).to eq 3
+      end
+      it 'should link to the subject hierarchically' do
+        expect(linked_subjects[0]).to match /^<a href=.*q=%22Subject2a%22.*>Subject2a<\/a>$/
+        expect(linked_subjects[1]).to match /^<a href=.*q=%22Subject2a\+Subject2b%22.*>Subject2b<\/a>$/
+        expect(linked_subjects[2]).to match /^<a href=.*q=%22Subject2a\+Subject2b\+Subject2c%22.*>Subject2c<\/a>$/
+      end
+      it 'should link to subject terms search field' do
+        linked_subjects.each do |subject|
+          expect(subject).to match /search_field=subject_terms/
+        end
+      end
+    end
+
+    describe '#link_mods_genres' do
+      let(:linked_genres) do
+        link_mods_genres(genres.first.values.last) do |text|
+          link_to(
+            text,
+            searches_path(
+              q: "\"#{[[], text.strip].flatten.join(' ')}\"",
+              search_field: 'subject_terms'
+            )
+          )
+        end
+      end
+
+      it 'should return correct link' do
+        expect(linked_genres).to match /<a href=*.*Genre3*.*<\/a>/
+      end
+      it 'should link to subject terms search field' do
+        expect(linked_genres).to match /search_field=subject_terms/
+      end
+    end
+
+    describe '#link_to_mods_subject' do
+      it 'should handle subjects that behave like names' do
+        name_subject = link_to_mods_subject(name_subjects.first.values.first, []) do |subject_text|
+          link_to(
+            subject_text,
+            searches_path(
+              q: "\"#{[[], subject_text.strip].flatten.join(' ')}\"",
+              search_field: 'subject_terms'
+            )
+          )
+        end
+        expect(name_subject).to match /<a href=.*%22Person\+Name%22.*>Person Name<\/a> \(Role1, Role2\)/
+      end
+    end
+  end
+
+  describe '#link_urls_and_email' do
+    let(:url) { 'This is a field that contains an https://library.stanford.edu URL' }
+    let(:email) { 'This is a field that contains an email@email.com address' }
+
+    it 'should link URLs' do
+      expect(link_urls_and_email(url)).to eq "This is a field that contains an <a href='https://library.stanford.edu'>https://library.stanford.edu</a> URL"
+    end
+    it 'should link email addresses' do
+      expect(link_urls_and_email(email)).to eq "This is a field that contains an <a href='mailto:email@email.com'>email@email.com</a> address"
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,11 @@
+ENV['RAILS_ENV'] ||= 'test'
 require 'mods_display'
 require 'stanford-mods'
 require 'capybara'
+require 'rails'
+require 'fake_app'
+require 'rspec/rails'
+require 'mods_display/helpers/record_helper'
 
 Dir["#{File.expand_path('..', __FILE__)}/fixtures/*.rb"].each { |file| require file }
 # Load i18n test file.
@@ -24,6 +29,7 @@ RSpec.configure do |config|
   # the seed, which is printed after each run.
   #     --seed 1234
   config.order = 'random'
+  config.include Rails.application.routes.url_helpers
 end
 class TestModel
   attr_accessor :modsxml


### PR DESCRIPTION
This pull request ports over the functionality from Purl and originally SearchWorks that provides the custom display of mods_display in the context of ActionView. The intent here being able to remove the `RecordHelper` modules from both applications.

The tests are ported over from SearchWorks to ensure compatibility there, with one large difference.

Currently in SearchWorks (uses all subjects):

```ruby
<%= mods_subject_field(document.mods.subject)%>
```

https://github.com/sul-dlss/SearchWorks/blob/4fc8b0d10d5f3f2ab02638f8ca901ce6735d7a45/app/views/catalog/record/_mods_subjects.html.erb#L2-L5

Currently in Purl (each subject):

```ruby
<% document.mods.subject.each do |subject| %>
  <%= mods_subject_field(subject)%>
<% end %>
```

https://github.com/sul-dlss/purl/blame/master/app/views/purl/_mods_subjects.html.erb#L3-L6

This code takes the "each subject" approach, so that SearchWorks will need to update how it handles that. Should be a simple change.

Running in Purl locally fs947tw3404

![Screen Shot 2021-02-12 at 4 53 09 PM](https://user-images.githubusercontent.com/1656824/107834199-d26c7080-6d52-11eb-9d7e-0b7854517d6b.png)

This sets us up to do: https://github.com/sul-dlss/exhibits/issues/1958 https://github.com/sul-dlss/exhibits/issues/1961 https://github.com/sul-dlss/exhibits/issues/697 