### PR TITLE
Adds the ability to obtain a raw ModsDisplay field type instead of a #fields array

### DIFF
--- a/lib/mods_display/html.rb
+++ b/lib/mods_display/html.rb
@@ -41,7 +41,9 @@ module ModsDisplay
       if to_s.respond_to?(method_name)
         to_html.send(method_name, *args, &block)
       elsif method_name == :subTitle || mods_display_fields.include?(method_name)
-        mods_field(@xml, method_name).fields
+        field = mods_field(@xml, method_name)
+        return field if (args.dig(0, :raw))
+        field.fields
       else
         super
       end

--- a/spec/integration/html_spec.rb
+++ b/spec/integration/html_spec.rb
@@ -79,4 +79,9 @@ describe 'HTML Output' do
       expect { @abstract.not_a_real_field }.to raise_error NoMethodError
     end
   end
+  describe 'individual fields' do
+    it 'should return ModsDispaly::Class when raw is specified' do
+      expect(@abstract.abstract(raw: true)).to be_a ModsDisplay::Abstract
+    end
+  end
 end


### PR DESCRIPTION
So downstream consumers could obtain an instance for other uses.

```erb
<%= document.mods.nestedRelatedItem(raw: true).to_html.html_safe %>
```