### PR TITLE
Don't force loading Rails

### DIFF
--- a/lib/mods_display.rb
+++ b/lib/mods_display.rb
@@ -38,4 +38,10 @@ I18n::Backend::Simple.send(:include, I18n::Backend::Fallbacks)
 I18n.load_path += Dir["#{File.expand_path('../..', __FILE__)}/config/locales/*.yml"]
 I18n.backend.load_translations
 
-require 'mods_display/engine'
+begin
+  require 'rails'
+rescue LoadError
+  #do nothing
+end
+
+require 'mods_display/engine' if defined?(Rails)

--- a/lib/mods_display/html.rb
+++ b/lib/mods_display/html.rb
@@ -56,7 +56,9 @@ module ModsDisplay
       view_context.render ModsDisplay::RecordComponent.new(record: self, fields: fields)
     end
 
-    MODS_DISPLAY_FIELD_MAPPING.except(:title).each do |key, _value|
+    MODS_DISPLAY_FIELD_MAPPING.each do |key, _value|
+      next if key == :title
+
       define_method(key) do |raw: false|
         field = mods_field(key)
         next field if raw


### PR DESCRIPTION
Some applications (like searchworks_traject_indexer) use the bit of mods_display that doesn't generate HTML or use any of the Rails-y stuff. I thought we could just inflict it on them anyway, but it's easier not to.