### PR TITLE
Avoid getting any global layout when rendering field components...

### DIFF
--- a/lib/mods_display/fields/contents.rb
+++ b/lib/mods_display/fields/contents.rb
@@ -14,7 +14,7 @@ module ModsDisplay
 
       component = ModsDisplay::FieldComponent.with_collection(f, value_transformer: value_transformer)
 
-      view_context.render component
+      view_context.render component, layout: false
     end
 
     private

--- a/lib/mods_display/fields/field.rb
+++ b/lib/mods_display/fields/field.rb
@@ -21,7 +21,7 @@ module ModsDisplay
     end
 
     def to_html(view_context = ApplicationController.renderer)
-      view_context.render ModsDisplay::FieldComponent.with_collection(fields, delimiter: delimiter)
+      view_context.render ModsDisplay::FieldComponent.with_collection(fields, delimiter: delimiter), layout: false
     end
 
     def render_in(view_context)

--- a/lib/mods_display/fields/name.rb
+++ b/lib/mods_display/fields/name.rb
@@ -19,7 +19,7 @@ module ModsDisplay
     def to_html(view_context = ApplicationController.renderer)
       component = ModsDisplay::FieldComponent.with_collection(fields, value_transformer: ->(value) { value.to_s })
 
-      view_context.render component
+      view_context.render component, layout: false
     end
 
     private

--- a/lib/mods_display/fields/nested_related_item.rb
+++ b/lib/mods_display/fields/nested_related_item.rb
@@ -23,7 +23,7 @@ module ModsDisplay
 
       component = ModsDisplay::FieldComponent.with_collection(fields, value_transformer: ->(value) { helpers.link_urls_and_email(value.to_s) })
 
-      view_context.render component
+      view_context.render component, layout: false
     end
 
     private
@@ -39,8 +39,10 @@ module ModsDisplay
     end
 
     def related_item_body(related_item)
-      return if related_item.body == '<dl></dl>'
-      related_item.body
+      body = related_item.body
+
+      return if body == '<dl></dl>'
+      body
     end
 
     def related_item_label(item)

--- a/lib/mods_display/fields/subject.rb
+++ b/lib/mods_display/fields/subject.rb
@@ -34,7 +34,7 @@ module ModsDisplay
         value_transformer: ->(value) { value.join(' > ') }
       )
 
-      view_context.render component
+      view_context.render component, layout: false
     end
 
     def process_hierarchicalGeographic(element)

--- a/lib/mods_display/html.rb
+++ b/lib/mods_display/html.rb
@@ -47,13 +47,13 @@ module ModsDisplay
     # Maybe have a separate class that will omit the first tite natively
     # and replace the first key in the the fields list with that.
     def body(view_context = ApplicationController.renderer)
-      view_context.render ModsDisplay::RecordComponent.new(record: self)
+      view_context.render ModsDisplay::RecordComponent.new(record: self), layout: false
     end
 
     # @deprecated
     def to_html(view_context = ApplicationController.renderer)
       fields = [:title] + ModsDisplay::RecordComponent::DEFAULT_FIELDS - [:subTitle]
-      view_context.render ModsDisplay::RecordComponent.new(record: self, fields: fields)
+      view_context.render ModsDisplay::RecordComponent.new(record: self, fields: fields), layout: false
     end
 
     MODS_DISPLAY_FIELD_MAPPING.each do |key, _value|


### PR DESCRIPTION
…by setting it explicitly to false.

I'm a little confused about how, exactly, to reproduce this, but it seems to be an issue with nested components 🤷‍♂️ 