### PR TITLE
Restore backwards compatiblity for NestedRelatedItems 

### DIFF
--- a/app/components/mods_display/list_field_component.html.erb
+++ b/app/components/mods_display/list_field_component.html.erb
@@ -2,8 +2,8 @@
   <%= tag.dt @field.label.sub(/:$/, ''), **@label_html_attributes %>
 <% end %>
 
-<%= tag.dd format_value(value), **@value_html_attributes %>
-  <% tag.ul **@list_html_attributes %>
+<%= tag.dd **@value_html_attributes do %>
+  <%= tag.ul **@list_html_attributes do %>
     <% @field.values.select(&:present?).each do |value| %>
       <%= tag.li format_value(value), **@list_item_html_attributes %>
     <% end %>

--- a/app/components/mods_display/list_field_component.rb
+++ b/app/components/mods_display/list_field_component.rb
@@ -1,7 +1,7 @@
 module ModsDisplay
   class ListFieldComponent < ModsDisplay::FieldComponent
-    def initialize(list_html_attributes: {}, list_item_html_attributes: {}, **args)
-      super(**args)
+    def initialize(field:, list_html_attributes: {}, list_item_html_attributes: {}, **args)
+      super(field: field, **args)
 
       @list_html_attributes = list_html_attributes
       @list_item_html_attributes = list_item_html_attributes

--- a/lib/mods_display/fields/nested_related_item.rb
+++ b/lib/mods_display/fields/nested_related_item.rb
@@ -21,7 +21,7 @@ module ModsDisplay
     def to_html(view_context = ApplicationController.renderer)
       helpers = view_context.respond_to?(:simple_format) ? view_context : ApplicationController.new.view_context
 
-      component = ModsDisplay::FieldComponent.with_collection(fields, value_transformer: ->(value) { helpers.link_urls_and_email(value.to_s) })
+      component = ModsDisplay::ListFieldComponent.with_collection(fields, value_transformer: ->(value) { helpers.link_urls_and_email(value.to_s) }, list_html_attributes: { class: 'mods_display_nested_related_items' }, list_item_html_attributes: { class: 'mods_display_nested_related_item open' })
 
       view_context.render component
     end


### PR DESCRIPTION
by presenting them in a ul with the appropriate classes...

I'm not sure why a ul + lis is better than repeating the dd, but exhibits has some javascript that expects things this way, so 🤷‍♂️  