### PR TITLE
Remove the license badges

### DIFF
--- a/lib/mods_display/fields/access_condition.rb
+++ b/lib/mods_display/fields/access_condition.rb
@@ -82,19 +82,16 @@ module ModsDisplay
     def license_statement(element)
       matches = element.text.match(/^(?<code>.*) (?<type>.*):(?<description>.*)$/)
 
-      return "<div>#{element.text}</div>" unless matches
+      return element.text unless matches
 
       code = matches[:code].downcase
       type = matches[:type].downcase
       description = license_description(code, type) || matches[:description]
       url = license_url(code, type)
-      output = "<div class='#{code}-#{type}'>"
-      output << if url
-                  "<a href='#{url}'>#{description}</a>"
-                else
-                  description
-                end
-      output << '</div>'
+
+      return "<a href='#{url}'>#{description}</a>" if url
+
+      description
     end
 
     def license_url(code, type)

--- a/spec/fields/access_condition_spec.rb
+++ b/spec/fields/access_condition_spec.rb
@@ -39,12 +39,6 @@ describe ModsDisplay::AccessCondition do
       end
     end
     describe 'licenses' do
-      it 'should add the appropriate classes to the html around the license' do
-        fields = mods_display_access_condition(@no_link_license_note).fields
-        expect(fields.length).to eq(1)
-        expect(fields.first.values.length).to eq(1)
-        expect(fields.first.values.first).to match(%r{^<div class='unknown-something'>.*</div>$})
-      end
       it 'should identify and link CreativeCommons licenses properly' do
         fields = mods_display_access_condition(@cc_license_note).fields
         expect(fields.length).to eq(1)


### PR DESCRIPTION
An alternative to #90..

We discussed dropping those awhile ago (May 2021) and Gary said:

> @ggeisler : [...] Even aside from the possibility that some of the new license options might not have badges to display, I just don’t think they really have a useful purpose. They feel more like a leftover idea from the early days of creative commons where they made the badges available and displaying them seemed like a good way to spread the word. But today, they just feel redundant with the text version of the license and require more effort to understand what they mean (even if we made them a bit bigger so the text is readable).