### PR TITLE
Drop displayForm logic on all fields except name; fixes #23

### DIFF
--- a/lib/mods_display/fields/field.rb
+++ b/lib/mods_display/fields/field.rb
@@ -9,7 +9,7 @@ module ModsDisplay
       return_fields = @values.map do |value|
         ModsDisplay::Values.new(
           label: displayLabel(value) || label,
-          values: [displayForm(@values) || value.text].flatten
+          values: [value.text]
         )
       end
       collapse_fields(return_fields)
@@ -32,12 +32,6 @@ module ModsDisplay
 
     def delimiter
       nil
-    end
-
-    def displayForm(element)
-      return element unless element # basically return nil
-      display = element.children.find { |c| c.name == 'displayForm' }
-      return display.text if display
     end
 
     def displayLabel(element)

--- a/lib/mods_display/fields/imprint.rb
+++ b/lib/mods_display/fields/imprint.rb
@@ -4,30 +4,26 @@ module ModsDisplay
     def fields
       return_fields = []
       @values.each do |value|
-        if imprint_display_form(value)
-          return_fields << imprint_display_form(value)
-        else
-          edition = edition_element(value)
-          place = place_element(value)
-          publisher = publisher_element(value)
-          parts = parts_element(value)
-          place_pub = compact_and_join_with_delimiter([place, publisher], ' : ')
-          edition_place = compact_and_join_with_delimiter([edition, place_pub], ' - ')
-          joined_place_parts = compact_and_join_with_delimiter([edition_place, parts], ', ')
-          unless joined_place_parts.empty?
+        edition = edition_element(value)
+        place = place_element(value)
+        publisher = publisher_element(value)
+        parts = parts_element(value)
+        place_pub = compact_and_join_with_delimiter([place, publisher], ' : ')
+        edition_place = compact_and_join_with_delimiter([edition, place_pub], ' - ')
+        joined_place_parts = compact_and_join_with_delimiter([edition_place, parts], ', ')
+        unless joined_place_parts.empty?
+          return_fields << ModsDisplay::Values.new(
+            label: displayLabel(value) || I18n.t('mods_display.imprint'),
+            values: [joined_place_parts]
+          )
+        end
+        return_fields.concat(dates(value)) if dates(value).length > 0
+        if other_pub_info(value).length > 0
+          other_pub_info(value).each do |pub_info|
             return_fields << ModsDisplay::Values.new(
-              label: displayLabel(value) || I18n.t('mods_display.imprint'),
-              values: [joined_place_parts]
+              label: displayLabel(value) || pub_info_labels[pub_info.name.to_sym],
+              values: [pub_info.text.strip]
             )
-          end
-          return_fields.concat(dates(value)) if dates(value).length > 0
-          if other_pub_info(value).length > 0
-            other_pub_info(value).each do |pub_info|
-              return_fields << ModsDisplay::Values.new(
-                label: displayLabel(value) || pub_info_labels[pub_info.name.to_sym],
-                values: [pub_info.text.strip]
-              )
-            end
           end
         end
       end
@@ -242,16 +238,6 @@ module ModsDisplay
         !term.attributes['type'].respond_to?(:value) ||
           term.attributes['type'].value == 'text'
       end
-    end
-
-    def imprint_display_form(element)
-      display_form = element.children.find do |child|
-        child.name == 'displayForm'
-      end
-      ModsDisplay::Values.new(
-        label: displayLabel(element) || I18n.t('mods_display.imprint'),
-        values: [display_form.text]
-      ) if display_form
     end
 
     private

--- a/lib/mods_display/fields/language.rb
+++ b/lib/mods_display/fields/language.rb
@@ -7,7 +7,7 @@ module ModsDisplay
           next unless term.attributes['type'].respond_to?(:value) && term.attributes['type'].value == 'code'
           ModsDisplay::Values.new(
             label: displayLabel(value) || displayLabel(term) || I18n.t('mods_display.language'),
-            values: [displayForm(value) || language_codes[term.text]].flatten
+            values: [language_codes[term.text]]
           )
         end.flatten.compact
       end.flatten.compact

--- a/lib/mods_display/fields/title.rb
+++ b/lib/mods_display/fields/title.rb
@@ -20,8 +20,6 @@ module ModsDisplay
     end
 
     def assemble_title(element)
-      return displayForm(element) if displayForm(element)
-
       title = ''
       previous_element = nil
 

--- a/spec/fields/imprint_spec.rb
+++ b/spec/fields/imprint_spec.rb
@@ -13,8 +13,6 @@ describe ModsDisplay::Imprint do
     @no_edition = Stanford::Mods::Record.new.from_str(no_edition_mods, false).origin_info
     @edition_and_date = Stanford::Mods::Record.new.from_str(origin_info_mods, false).origin_info
     @mixed = Stanford::Mods::Record.new.from_str(mixed_mods, false).origin_info
-    @display_form = Stanford::Mods::Record.new.from_str(display_form, false).origin_info
-    @display_form_with_label = Stanford::Mods::Record.new.from_str(display_form, false).origin_info
     @display_label = Stanford::Mods::Record.new.from_str(display_label, false).origin_info
     @date_range = Stanford::Mods::Record.new.from_str(date_range, false).origin_info
     @open_date_range = Stanford::Mods::Record.new.from_str(open_date_range, false).origin_info
@@ -249,14 +247,6 @@ describe ModsDisplay::Imprint do
     end
   end
   describe 'to_html' do
-    it 'should return the display form if one is available' do
-      html = mods_display_imprint(@display_form).to_html
-      expect(html.scan(/<dd>/).length).to eq(2)
-      expect(html.scan(%r{<dd>The Display Form</dd>}).length).to eq(2)
-    end
-    it "should return the displayLabel when present if we're using the displayForm" do
-      expect(mods_display_imprint(@display_form_with_label).to_html).to match(%r{<dt>TheLabel</dt>})
-    end
     it 'should have individual dt/dd pairs for mixed content' do
       html = mods_display_imprint(@mixed).to_html
       expect(html.scan(%r{<dt>Imprint</dt>}).length).to eq(1)

--- a/spec/fields/language_spec.rb
+++ b/spec/fields/language_spec.rb
@@ -25,9 +25,6 @@ describe ModsDisplay::Language do
         <language><languageTerm type='code'>ger</languageTerm><languageTerm type='code'>eng</languageTerm></language>
       </mods>", false
     ).language
-    @display_form = Stanford::Mods::Record.new.from_str(
-      '<mods><language><languageTerm>zzzxxx</languageTerm><displayForm>Klingon</displayForm></language></mods>', false
-    ).language
   end
   describe 'fields' do
     it 'should return an array with a label/values object' do

--- a/spec/fields/title_spec.rb
+++ b/spec/fields/title_spec.rb
@@ -11,7 +11,6 @@ describe ModsDisplay::Title do
     @title_parts = Stanford::Mods::Record.new.from_str(title_parts_fixture, false).title_info
     @reverse_title_parts = Stanford::Mods::Record.new.from_str(reverse_title_parts_fixture, false).title_info
     @display_label = Stanford::Mods::Record.new.from_str(display_label_fixture, false).title_info
-    @display_form = Stanford::Mods::Record.new.from_str(display_form_fixture, false).title_info
     @multi_label = Stanford::Mods::Record.new.from_str(multi_label_fixture, false).title_info
     @alt_title = Stanford::Mods::Record.new.from_str(alt_title_fixture, false).title_info
     @title_punctuation = Stanford::Mods::Record.new.from_str(title_puncutation_fixture, false).title_info
@@ -55,10 +54,6 @@ describe ModsDisplay::Title do
       expect(mods_display_title(@reverse_title_parts).fields.first.values).to include(
         'The Title : For. Part 62, Something'
       )
-    end
-
-    it 'should use the displayForm when available' do
-      expect(mods_display_title(@display_form).fields.first.values).to include 'The Title of This Item'
     end
 
     it 'should return the basic text held in a sub element of titleInfo' do

--- a/spec/fixtures/imprint_fixtures.rb
+++ b/spec/fixtures/imprint_fixtures.rb
@@ -54,23 +54,6 @@ module ImprintFixtures
     MODS
   end
 
-  def display_form
-    <<-MODS
-      <mods>
-        <originInfo>
-          <place><placeTerm>A Place</placeTerm></place>
-          <publisher>A Publisher</publisher>
-          <displayForm>The Display Form</displayForm>
-        </originInfo>
-        <originInfo displayLabel="TheLabel">
-          <place><placeTerm>A Place</placeTerm></place>
-          <publisher>A Publisher</publisher>
-          <displayForm>The Display Form</displayForm>
-        </originInfo>
-      </mods>
-    MODS
-  end
-
   def display_label
     <<-MODS
       <mods>

--- a/spec/fixtures/title_fixtures.rb
+++ b/spec/fixtures/title_fixtures.rb
@@ -45,17 +45,6 @@ module TitleFixtures
     XML
   end
 
-  def display_form_fixture
-    <<-XML
-      <mods>
-        <titleInfo>
-          <title>Title</title>
-          <displayForm>The Title of This Item</displayForm>
-        </titleInfo>
-      </mods>
-    XML
-  end
-
   def multi_label_fixture
     <<-XML
       <mods>


### PR DESCRIPTION
Apparently `mods:name` is the only schema-valid container for `displayForm`, and it doesn't show up elsewhere if our published MODS