### PR TITLE
Munge nested related items nodes instead of trying to re-parse it from strings

### DIFF
--- a/lib/mods_display/fields/nested_related_item.rb
+++ b/lib/mods_display/fields/nested_related_item.rb
@@ -37,7 +37,13 @@ module ModsDisplay
 
     def related_item_mods_object(value)
       mods = ::Stanford::Mods::Record.new.tap do |r|
-        r.from_str("<mods xmlns=\"http://www.loc.gov/mods/v3\">#{value.children.to_xml}</mods>")
+        # dup'ing the value adds the appropriate namespaces, but...
+        munged_node = value.dup.tap do |x|
+          # ... the mods gem also expects the root of the document to have the root tag <mods>
+          x.name = 'mods'
+        end
+
+        r.from_nk_node(munged_node)
       end
       related_item = ModsDisplay::HTML.new(mods)
 

--- a/spec/fields/nested_related_item_spec.rb
+++ b/spec/fields/nested_related_item_spec.rb
@@ -77,5 +77,19 @@ describe ModsDisplay::NestedRelatedItem do
         end
       end
     end
+
+    describe 'with a namespace prefix' do
+      let(:mods) { namespace_prefixed_related_item_fixture }
+
+      it 'renders the list' do
+        within(html.first('dd')) do |dd|
+          expect(dd).to have_css('ul.mods_display_nested_related_items')
+          within(dd.find('ul.mods_display_nested_related_items li')) do |li|
+            expect(li).to have_css('dl dt', text: 'Constituent Title:')
+            expect(li).to have_css('dl dd', text: 'Constituent note')
+          end
+        end
+      end
+    end
   end
 end

--- a/spec/fixtures/nested_realted_items_fixtures.rb
+++ b/spec/fixtures/nested_realted_items_fixtures.rb
@@ -14,6 +14,19 @@ module NestedRelatedItemFixtures
     XML
   end
 
+  def namespace_prefixed_related_item_fixture
+    <<-XML
+      <mods:mods xmlns:xforms="http://www.w3.org/2002/xforms" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mods="http://www.loc.gov/mods/v3" xmlns:xxforms="http://orbeon.org/oxf/xml/xforms">
+        <mods:relatedItem type="constituent">
+          <mods:titleInfo>
+            <mods:title>Constituent Title</mods:title>
+          </mods:titleInfo>
+          <mods:note>Constituent note</mods:note>
+        </mods:relatedItem>
+      </mods:mods>
+    XML
+  end
+
   def multi_constituent_fixture
     <<-XML
       <mods xmlns="http://www.loc.gov/mods/v3">


### PR DESCRIPTION
The string concatenation approach doesn't play nice with documents with a non-default prefix (resulting in MODs documents like:

```xml
<mods xmlns="...">
  <mods:titleInfo>...</mods:titleInfo>
</mods>
```

Note the default xmlns, and the un-bound prefix `mods:`..)

... but there's no reason to parse and reparse the document in the first place, when we can just munge the parsed data to match what we expect.

This wasn't a problem with the previous version of mods_display because we just stripped all the XML namespaces... it's also not clear that it's an actual problem with our production data because it all seems to use MODS as the default namespace, but better safe than sorry. 