### PR TITLE
Apply simple formatting to convert newlines to HTML 

### DIFF
--- a/app/components/mods_display/field_component.rb
+++ b/app/components/mods_display/field_component.rb
@@ -22,7 +22,7 @@ module ModsDisplay
       if @value_transformer
         @value_transformer.call(value)
       else
-        helpers.link_urls_and_email(value)
+        helpers.format_mods_html(value, field: @field)
       end
     end
   end

--- a/app/helpers/mods_display/record_helper.rb
+++ b/app/helpers/mods_display/record_helper.rb
@@ -74,7 +74,16 @@ module ModsDisplay
     def link_urls_and_email(val, tags: %w[a dl dd dt i b em strong cite br])
       val = val.gsub(%r{<[^/> ]+}) do |possible_tag|
         # Allow potentially valid HTML tags through to the sanitizer step, and HTML escape the rest
-        if tags.include? possible_tag[1..]
+        if tags.include?(possible_tag[1..])
+          possible_tag
+        else
+          "&lt;#{possible_tag[1..]}"
+        end
+      end
+
+      val = val.gsub(%r{</[^> ]+}) do |possible_tag|
+        # Allow potentially valid HTML tags through to the sanitizer step, and HTML escape the rest
+        if tags.include?(possible_tag[2..])
           possible_tag
         else
           "&lt;#{possible_tag[1..]}"

--- a/app/helpers/mods_display/record_helper.rb
+++ b/app/helpers/mods_display/record_helper.rb
@@ -69,9 +69,7 @@ module ModsDisplay
       link
     end
 
-    # rubocop:disable Layout/LineLength
-    # @private, but used in PURL currently
-    def link_urls_and_email(val, tags: %w[a dl dd dt i b em strong cite br])
+    def format_mods_html(val, tags: %w[a dl dd dt i b em strong cite br], field: nil)
       val = val.gsub(%r{<[^/> ]+}) do |possible_tag|
         # Allow potentially valid HTML tags through to the sanitizer step, and HTML escape the rest
         if tags.include?(possible_tag[1..])
@@ -107,7 +105,23 @@ module ModsDisplay
         end
       end
 
-      sanitize val, tags: tags, attributes: %w[href]
+      formatted_val = sanitize val, tags: tags, attributes: %w[href]
+
+      # Martin Wong data has significant linebreaks in abstracts and notes that we want
+      # to preserve and display in HTML.
+      #
+      # See https://github.com/sul-dlss/mods_display/issues/78
+      if (field&.field.is_a?(ModsDisplay::Abstract) || field&.field.is_a?(ModsDisplay::Note)) && formatted_val.include?("\n")
+        simple_format(formatted_val, {}, sanitize: false)
+      else
+        formatted_val
+      end
+    end
+
+    # rubocop:disable Layout/LineLength
+    # @private, but used in PURL currently
+    def link_urls_and_email(val, tags: %w[a dl dd dt i b em strong cite br])
+      format_mods_html(val, tags: tags)
     end
     # rubocop:enable Layout/LineLength
   end

--- a/app/helpers/mods_display/record_helper.rb
+++ b/app/helpers/mods_display/record_helper.rb
@@ -111,7 +111,8 @@ module ModsDisplay
       # to preserve and display in HTML.
       #
       # See https://github.com/sul-dlss/mods_display/issues/78
-      if (field&.field.is_a?(ModsDisplay::Abstract) || field&.field.is_a?(ModsDisplay::Note)) && formatted_val.include?("\n")
+      simple_formatted_fields = [ModsDisplay::Abstract, ModsDisplay::Contents, ModsDisplay::Note]
+      if simple_formatted_fields.any? { |klass| field&.field.is_a? klass } && formatted_val.include?("\n")
         simple_format(formatted_val, {}, sanitize: false)
       else
         formatted_val

--- a/lib/mods_display/fields/contents.rb
+++ b/lib/mods_display/fields/contents.rb
@@ -4,7 +4,7 @@ module ModsDisplay
   class Contents < Field
     def to_html(view_context = ApplicationController.renderer)
       f = fields.map do |field|
-        ModsDisplay::Values.new(label: field.label, values: [field.values.join("\n\n")])
+        ModsDisplay::Values.new(label: field.label, values: [field.values.join("\n\n")], field: self)
       end
 
       helpers = view_context.respond_to?(:simple_format) ? view_context : ApplicationController.new.view_context

--- a/lib/mods_display/fields/field.rb
+++ b/lib/mods_display/fields/field.rb
@@ -10,7 +10,8 @@ module ModsDisplay
       return_fields = @values.map do |value|
         ModsDisplay::Values.new(
           label: displayLabel(value) || label,
-          values: [element_text(value)]
+          values: [element_text(value)],
+          field: self
         )
       end
       collapse_fields(return_fields)

--- a/lib/mods_display/fields/nested_related_item.rb
+++ b/lib/mods_display/fields/nested_related_item.rb
@@ -25,7 +25,7 @@ module ModsDisplay
 
       component = ModsDisplay::ListFieldComponent.with_collection(
         fields,
-        value_transformer: ->(value) { helpers.link_urls_and_email(value.to_s) },
+        value_transformer: ->(value) { helpers.format_mods_html(value.to_s) },
         list_html_attributes: { class: 'mods_display_nested_related_items' },
         list_item_html_attributes: { class: 'mods_display_nested_related_item open' }
       )

--- a/lib/mods_display/fields/note.rb
+++ b/lib/mods_display/fields/note.rb
@@ -4,7 +4,7 @@ module ModsDisplay
   class Note < Field
     def fields
       return_fields = note_fields.map do |value|
-        ModsDisplay::Values.new(label: displayLabel(value) || note_label(value), values: [element_text(value)])
+        ModsDisplay::Values.new(label: displayLabel(value) || note_label(value), values: [element_text(value)], field: self)
       end
       collapse_fields(return_fields)
     end

--- a/lib/mods_display/fields/values.rb
+++ b/lib/mods_display/fields/values.rb
@@ -2,11 +2,12 @@
 
 module ModsDisplay
   class Values
-    attr_accessor :label, :values
+    attr_accessor :label, :values, :field
 
-    def initialize(label: nil, values: [])
+    def initialize(label: nil, values: [], field: nil)
       @label = label
       @values = values
+      @field = field
     end
   end
 end

--- a/spec/helpers/record_helper_spec.rb
+++ b/spec/helpers/record_helper_spec.rb
@@ -237,5 +237,9 @@ describe ModsDisplay::RecordHelper, type: :helper do
       expected = 'Dustin Schroeder and the Scott Polar Research Institute, 2018. &lt;"Multidecadal observations of the Antarctic ice sheet from restored analog radar records" <a href="https://doi.org/10.1073/pnas.1821646116">https://doi.org/10.1073/pnas.1821646116</a>&gt;'
       expect(link_urls_and_email(value)).to eq expected
     end
+
+    it 'strips out paragraph tags' do
+      expect(format_mods_html('<p>blah</p>')).to eq '&lt;p&gt;blah&lt;/p&gt;'
+    end
   end
 end

--- a/spec/helpers/record_helper_spec.rb
+++ b/spec/helpers/record_helper_spec.rb
@@ -30,7 +30,7 @@ describe ModsDisplay::RecordHelper, type: :helper do
   describe 'mods_record_field' do
     let(:mods_field) { OpenStruct.new(label: 'test', values: ['hello, there']) }
     let(:url_field) { OpenStruct.new(label: 'test', values: ['https://library.stanford.edu']) }
-    let(:multi_values) { double(label: 'test', values: %w[123 321]) }
+    let(:multi_values) { double(label: 'test', values: %w[123 321], field: nil) }
 
     it 'returns correct content' do
       expect(helper.mods_record_field(mods_field)).to have_css('dt', text: 'test')
@@ -220,22 +220,34 @@ describe ModsDisplay::RecordHelper, type: :helper do
     end
   end
 
-  describe '#link_urls_and_email' do
+  describe '#format_mods_html' do
     let(:url) { 'This is a field that contains an https://library.stanford.edu URL' }
     let(:email) { 'This is a field that contains an email@email.com address' }
 
     it 'links URLs' do
-      expect(link_urls_and_email(url)).to eq 'This is a field that contains an <a href="https://library.stanford.edu">https://library.stanford.edu</a> URL'
+      expect(format_mods_html(url)).to eq 'This is a field that contains an <a href="https://library.stanford.edu">https://library.stanford.edu</a> URL'
     end
 
     it 'links email addresses' do
-      expect(link_urls_and_email(email)).to eq 'This is a field that contains an <a href="mailto:email@email.com">email@email.com</a> address'
+      expect(format_mods_html(email)).to eq 'This is a field that contains an <a href="mailto:email@email.com">email@email.com</a> address'
     end
 
     it 'leaves closing punction out of the url' do
       value = 'Dustin Schroeder and the Scott Polar Research Institute, 2018. &lt;"Multidecadal observations of the Antarctic ice sheet from restored analog radar records" https://doi.org/10.1073/pnas.1821646116&gt;'
       expected = 'Dustin Schroeder and the Scott Polar Research Institute, 2018. &lt;"Multidecadal observations of the Antarctic ice sheet from restored analog radar records" <a href="https://doi.org/10.1073/pnas.1821646116">https://doi.org/10.1073/pnas.1821646116</a>&gt;'
-      expect(link_urls_and_email(value)).to eq expected
+      expect(format_mods_html(value)).to eq expected
+    end
+
+    it 'ignores new lines in most fields' do
+      expect(format_mods_html("this\nthat")).to eq "this\nthat"
+    end
+
+    it 'formats newline characters for abstracts' do
+      expect(format_mods_html("this\nthat", field: ModsDisplay::Values.new(field: ModsDisplay::Abstract.new(nil)))).to eq "<p>this\n<br />that</p>"
+    end
+
+    it 'formats newline characters for notes' do
+      expect(format_mods_html("this\nthat", field: ModsDisplay::Values.new(field: ModsDisplay::Note.new(nil)))).to eq "<p>this\n<br />that</p>"
     end
 
     it 'strips out paragraph tags' do

--- a/spec/integration/html_spec.rb
+++ b/spec/integration/html_spec.rb
@@ -128,5 +128,19 @@ describe 'HTML Output' do
         expect(html).to match(%r{<dd><i>Some title</i> in an abstract</dd>})
       end
     end
+
+    context 'with consecutive new line characters' do
+      let(:mods) do
+        <<-XML
+          <mods xmlns=\"http://www.loc.gov/mods/v3\">
+            <abstract>blah\n\nblah</abstract>
+          </mods>
+        XML
+      end
+
+      it 'passes xml entities through' do
+        expect(html).to match(%r{<dd><p>blah</p>\n\n<p>blah</p></dd>})
+      end
+    end
   end
 end


### PR DESCRIPTION
...but only applied to abstract + note fields.

We're limiting this just to abstract + notes field in order to limit the impact of unintentional or insignificant whitespace turning into HTML in fields where it may be more impactful (titles, controlled vocabulary fields, etc). We expect it _might_ be fine, but this way we can fix https://github.com/sul-dlss/mods_display/issues/78 for the Wong data and deal with the rest without a hard deadline looming.

