### PR TITLE
Don't convert title field to html-safe

### DIFF
--- a/lib/mods_display/fields/title.rb
+++ b/lib/mods_display/fields/title.rb
@@ -24,7 +24,7 @@ module ModsDisplay
       previous_element = nil
 
       element.children.select { |value| title_parts.include? value.name }.each do |value|
-        str = element_text(value)
+        str = value.text.strip
         next if str.empty?
 
         delimiter = if title.empty? || title.end_with?(' ')


### PR DESCRIPTION
Fixes https://github.com/sul-dlss/purl/issues/597

This essentially reverts back what we do to the title field from before [this PR](https://github.com/sul-dlss/mods_display/commit/e8c6bb160e5e26fd1fd5a562a57c69387c33d052#diff-72253ea8380aae9e87c6c299c8183676b9a7241e3b6598036544c4de85407559R57)

Titles are deployed in non-html-safe situations. In the future, if we need to have italics or other formatting in titles, we may have to revisit this choice.