### PR TITLE
Decode XML entities in mods name fields

### DIFF
--- a/lib/mods_display/fields/name.rb
+++ b/lib/mods_display/fields/name.rb
@@ -30,6 +30,11 @@ module ModsDisplay
       '<br />'
     end
 
+    # Override of Field#element_text to get text rather than HTML
+    def element_text(element)
+      element.text.strip
+    end
+
     def collapse_roles(fields)
       return [] if fields.blank?
 

--- a/spec/fields/name_spec.rb
+++ b/spec/fields/name_spec.rb
@@ -70,6 +70,11 @@ describe ModsDisplay::Name do
       expect(fields.first.values.first.name).to eq('Mr. John Doe')
     end
 
+    it 'decodes XML entities' do
+      fields = mods_display_name(Stanford::Mods::Record.new.from_str(entities_name_fixture).plain_name).fields
+      expect(fields.first.values.first.name).to eq('J. & C. Walker')
+    end
+
     it 'does not add blank names' do
       expect(mods_display_name(@blank_name).fields).to eq([])
     end

--- a/spec/fixtures/name_fixtures.rb
+++ b/spec/fixtures/name_fixtures.rb
@@ -126,6 +126,16 @@ module NameFixtures
     XML
   end
 
+  def entities_name_fixture
+    <<-XML
+      <mods xmlns="http://www.loc.gov/mods/v3">
+        <name type="corporate">
+          <namePart>J. &amp; C. Walker</namePart>
+        </name>
+      </mods>
+    XML
+  end
+
   def collapse_label_name_fixture
     <<-XML
       <mods xmlns="http://www.loc.gov/mods/v3">


### PR DESCRIPTION
Fixes the ampersand display in the contributor field in [this record](https://purl.stanford.edu/td928kc6828).
Before:
<img width="339" alt="Screenshot 2023-02-14 at 1 31 49 PM" src="https://user-images.githubusercontent.com/458247/218826350-85318f87-1afa-46c7-8103-4033b298bf39.png">

After:
<img width="312" alt="Screenshot 2023-02-14 at 1 33 11 PM" src="https://user-images.githubusercontent.com/458247/218826585-51743072-19a1-4c16-b1f2-aac57696f46b.png">
