### PR TITLE
Support newlines in access conditions

### DIFF
--- a/app/helpers/mods_display/record_helper.rb
+++ b/app/helpers/mods_display/record_helper.rb
@@ -90,8 +90,12 @@ module ModsDisplay
       # Martin Wong data has significant linebreaks in abstracts and notes that we want
       # to preserve and display in HTML.
       #
+      # Some user-deposited items have complex use and reproduction statements that also
+      # need linebreaks preserved.
+      #
       # See https://github.com/sul-dlss/mods_display/issues/78
-      simple_formatted_fields = [ModsDisplay::Abstract, ModsDisplay::Contents, ModsDisplay::Note]
+      # and https://github.com/sul-dlss/mods_display/issues/145
+      simple_formatted_fields = [ModsDisplay::Abstract, ModsDisplay::Contents, ModsDisplay::Note, ModsDisplay::AccessCondition]
       if simple_formatted_fields.any? { |klass| field&.field.is_a? klass } && formatted_val.include?("\n")
         simple_format(formatted_val, {}, sanitize: false)
       else

--- a/spec/fields/access_condition_spec.rb
+++ b/spec/fields/access_condition_spec.rb
@@ -13,6 +13,7 @@ describe ModsDisplay::AccessCondition do
   before :all do
     @access_condition = Stanford::Mods::Record.new.from_str(simple_access_condition_fixture).accessCondition
     @restrict_condition = Stanford::Mods::Record.new.from_str(restricted_access_fixture).accessCondition
+    @custom_use_reproduction = Stanford::Mods::Record.new.from_str(custom_use_reproduction_fixture).accessCondition
     @copyright_note = Stanford::Mods::Record.new.from_str(copyright_access_fixture).accessCondition
     @cc_license_note = Stanford::Mods::Record.new.from_str(cc_license_fixture).accessCondition
     @odc_license_note = Stanford::Mods::Record.new.from_str(odc_license_fixture).accessCondition
@@ -82,6 +83,14 @@ describe ModsDisplay::AccessCondition do
           'Unknown garbage that does not look like a license'
         )
         expect(fields.first.values.first).not_to include('<a.*>')
+      end
+    end
+
+    describe 'use and reproduction' do
+      it 'preserves newlines' do
+        fields = mods_display_access_condition(@custom_use_reproduction).fields
+        expect(fields.length).to eq(1)
+        expect(fields.first.values).to eq ["Special use agreement\n\nText of the agreement"]
       end
     end
   end

--- a/spec/fixtures/access_condition_fixtures.rb
+++ b/spec/fixtures/access_condition_fixtures.rb
@@ -16,6 +16,14 @@ module AccessConditionFixtures
     XML
   end
 
+  def custom_use_reproduction_fixture
+    <<-XML
+      <mods xmlns="http://www.loc.gov/mods/v3">
+        <accessCondition type='useAndReproduction'>Special use agreement&#10;&#10;Text of the agreement</accessCondition>
+      </mods>
+    XML
+  end
+
   def copyright_access_fixture
     <<-XML
       <mods xmlns="http://www.loc.gov/mods/v3">


### PR DESCRIPTION
This extends the same approach used in #78 to support the Access
Condition element, which includes Use & Reproduction Statements.

Closes #145
