### PR TITLE
Update access condition handling

### DIFF
--- a/lib/mods_display/fields/access_condition.rb
+++ b/lib/mods_display/fields/access_condition.rb
@@ -54,7 +54,8 @@ module ModsDisplay
       return_fields = @values.map do |value|
         ModsDisplay::Values.new(
           label: displayLabel(value) || access_label(value),
-          values: [process_access_statement(value)]
+          values: [process_access_statement(value)],
+          field: self
         )
       end
       collapse_fields(return_fields)

--- a/spec/helpers/record_helper_spec.rb
+++ b/spec/helpers/record_helper_spec.rb
@@ -246,6 +246,11 @@ RSpec.describe ModsDisplay::RecordHelper, type: :helper do
                               field: ModsDisplay::Values.new(field: ModsDisplay::Abstract.new(nil)))).to eq "<p>this\n<br />that</p>"
     end
 
+    it 'formats newline characters for access conditions' do
+      expect(format_mods_html("This is a\n\nuse statement",
+                              field: ModsDisplay::Values.new(field: ModsDisplay::AccessCondition.new(nil)))).to eq "<p>This is a</p>\n\n<p>use statement</p>"
+    end
+
     it 'formats newline characters for notes' do
       expect(format_mods_html("this\nthat",
                               field: ModsDisplay::Values.new(field: ModsDisplay::Note.new(nil)))).to eq "<p>this\n<br />that</p>"


### PR DESCRIPTION
Small tweak to get accessConditions to display linebreaks when in MODS as `&#10;`. (Follows changes made in https://github.com/sul-dlss/mods_display/pull/120/files#diff-0c6dc9b4ecb8315b77c7c8e1e952ed1c6457944ac8e205c7c0fe19150d88bf60)