### PR TITLE
refactor: Field now uses @stanford_mods_element instead of @values

### DIFF
--- a/lib/mods_display/fields/access_condition.rb
+++ b/lib/mods_display/fields/access_condition.rb
@@ -51,10 +51,10 @@ module ModsDisplay
     }.freeze
 
     def fields
-      return_fields = @values.map do |value|
+      return_fields = @stanford_mods_elements.map do |stanford_mods_element|
         ModsDisplay::Values.new(
-          label: displayLabel(value) || access_label(value),
-          values: [process_access_statement(value)],
+          label: displayLabel(stanford_mods_element) || access_label(stanford_mods_element),
+          values: [process_access_statement(stanford_mods_element)],
           field: self
         )
       end
@@ -85,7 +85,7 @@ module ModsDisplay
     def license_statement(element)
       element_text = element_text(element)
       legacy_matches = element_text.match(/^(?<code>.*) (?<type>.*):(?<description>.*)$/)
-      return legacy_license_statement(element, legacy_matches) if legacy_matches
+      return legacy_license_statement(legacy_matches) if legacy_matches
 
       matches = element_text.match(/^This work is licensed under a (.+?)\.$/)
       return linked_licensed_statement(element, matches) if matches && element['xlink:href'].present?
@@ -97,7 +97,7 @@ module ModsDisplay
       "This work is licensed under a <a href='#{element['xlink:href']}'>#{matches[1]}</a>."
     end
 
-    def legacy_license_statement(_element, matches)
+    def legacy_license_statement(matches)
       code = matches[:code].downcase
       type = matches[:type].downcase
       description = license_description(code, type) || matches[:description]

--- a/lib/mods_display/fields/cartographics.rb
+++ b/lib/mods_display/fields/cartographics.rb
@@ -3,20 +3,18 @@
 module ModsDisplay
   class Cartographics < Field
     def fields
-      return nil if @values.nil?
+      return nil if @stanford_mods_elements.nil?
 
       return_fields = []
-      @values.each do |value|
-        next unless value.respond_to?(:cartographics)
+      @stanford_mods_elements.each do |subject_element|
+        next unless subject_element.respond_to?(:cartographics)
 
-        value.cartographics.each do |field|
+        subject_element.cartographics.each do |field|
           scale = field.scale.empty? ? 'Scale not given' : element_text(field.scale)
           projection = field.projection.empty? ? nil : element_text(field.projection)
           coordinates = field.coordinates.empty? ? nil : element_text(field.coordinates)
-          post_scale = if [projection,
-                           coordinates].compact.length.positive?
-                         [projection, coordinates].compact.join(' ')
-                       end
+          post_scale = [projection, coordinates].compact.join(' ') if [projection, coordinates].compact.length.positive?
+
           return_fields << ModsDisplay::Values.new(
             label: displayLabel(field) || label || I18n.t('mods_display.map_data'),
             values: [[scale, post_scale].compact.join(' ; ')]

--- a/lib/mods_display/fields/collection.rb
+++ b/lib/mods_display/fields/collection.rb
@@ -5,18 +5,18 @@ module ModsDisplay
   #  Collection class to parse collection data out of Mods relatedItem fields
   ###
   class Collection < Field
-    def collection_label(value)
-      displayLabel(value) || I18n.t('mods_display.collection')
+    def collection_label(related_item_element)
+      displayLabel(related_item_element) || I18n.t('mods_display.collection')
     end
 
     def fields
       return_fields = []
-      @values.each do |value|
-        next unless related_item_is_a_collection?(value)
+      @stanford_mods_elements.each do |related_item_element|
+        next unless related_item_is_a_collection?(related_item_element)
 
         return_fields << ModsDisplay::Values.new(
-          label: collection_label(value),
-          values: [element_text(value.titleInfo)]
+          label: collection_label(related_item_element),
+          values: [element_text(related_item_element.titleInfo)]
         )
       end
       collapse_fields(return_fields)
@@ -24,17 +24,17 @@ module ModsDisplay
 
     private
 
-    def related_item_is_a_collection?(value)
-      value.respond_to?(:titleInfo) && resource_type_is_collection?(value)
+    def related_item_is_a_collection?(related_item_element)
+      related_item_element.respond_to?(:titleInfo) && resource_type_is_collection?(related_item_element)
     end
 
-    def resource_type_is_collection?(value)
-      return false unless value.respond_to?(:typeOfResource)
-      return false unless value.typeOfResource.attributes.length.positive?
+    def resource_type_is_collection?(related_item_element)
+      return false unless related_item_element.respond_to?(:typeOfResource)
+      return false unless related_item_element.typeOfResource.attributes.length.positive?
 
-      value.typeOfResource.attributes.length.positive? &&
-        value.typeOfResource.attributes.first.key?('collection') &&
-        value.typeOfResource.attributes.first['collection'].value == 'yes'
+      related_item_element.typeOfResource.attributes.length.positive? &&
+        related_item_element.typeOfResource.attributes.first.key?('collection') &&
+        related_item_element.typeOfResource.attributes.first['collection'].value == 'yes'
     end
   end
 end

--- a/lib/mods_display/fields/contact.rb
+++ b/lib/mods_display/fields/contact.rb
@@ -3,10 +3,10 @@
 module ModsDisplay
   class Contact < Field
     def fields
-      return_fields = contact_fields.map do |value|
+      return_fields = contact_elements.map do |contact_element|
         ModsDisplay::Values.new(
-          label: displayLabel(value) || I18n.t('mods_display.contact'),
-          values: [element_text(value)]
+          label: displayLabel(contact_element) || I18n.t('mods_display.contact'),
+          values: [element_text(contact_element)]
         )
       end
       collapse_fields(return_fields)
@@ -14,10 +14,10 @@ module ModsDisplay
 
     private
 
-    def contact_fields
-      @values.select do |value|
-        value.attributes['type'].respond_to?(:value) &&
-          value.attributes['type'].value.downcase == 'contact'
+    def contact_elements
+      @stanford_mods_elements.select do |note_element|
+        note_element.attributes['type'].respond_to?(:value) &&
+          note_element.attributes['type'].value.downcase == 'contact'
       end
     end
   end

--- a/lib/mods_display/fields/contents.rb
+++ b/lib/mods_display/fields/contents.rb
@@ -4,7 +4,11 @@ module ModsDisplay
   class Contents < Field
     def to_html(view_context = ApplicationController.renderer)
       f = fields.map do |field|
-        ModsDisplay::Values.new(label: field.label, values: [field.values.join("\n\n")], field: self)
+        ModsDisplay::Values.new(
+          label: field.label,
+          values: [field.values.join("\n\n")],
+          field: self
+        )
       end
 
       helpers = view_context.respond_to?(:simple_format) ? view_context : ApplicationController.new.view_context

--- a/lib/mods_display/fields/description.rb
+++ b/lib/mods_display/fields/description.rb
@@ -3,8 +3,11 @@
 module ModsDisplay
   class Description < Field
     def fields
-      return_fields = description_fields.map do |value|
-        ModsDisplay::Values.new(label: description_label(value), values: [element_text(value)])
+      return_fields = description_fields.map do |element|
+        ModsDisplay::Values.new(
+          label: description_label(element),
+          values: [element_text(element)]
+        )
       end
       collapse_fields(return_fields)
     end
@@ -16,7 +19,7 @@ module ModsDisplay
     private
 
     def description_fields
-      @values.children.select do |child|
+      @stanford_mods_elements.children.select do |child|
         labels.keys.include?(child.name.to_sym)
       end
     end

--- a/lib/mods_display/fields/edition.rb
+++ b/lib/mods_display/fields/edition.rb
@@ -3,11 +3,11 @@
 module ModsDisplay
   class Edition < Field
     def fields
-      return_fields = @values.map do |value|
-        edition_value = Stanford::Mods::Imprint.new(value).edition_vals_str
+      return_fields = @stanford_mods_elements.map do |origin_info_element|
+        edition_value = Stanford::Mods::Imprint.new(origin_info_element).edition_vals_str
         next unless edition_value.present?
 
-        # remove trailing spaces (thanks MARC for catalog card formatting!)
+        # remove trailing spaces (thanks MARC, for catalog card formatting!)
         edition_value.gsub!(%r{ */$}, '')
 
         ModsDisplay::Values.new(

--- a/lib/mods_display/fields/extent.rb
+++ b/lib/mods_display/fields/extent.rb
@@ -3,20 +3,20 @@
 module ModsDisplay
   class Extent < Field
     def fields
-      return [] unless extent_fields.present?
+      return [] unless extent_elements.present?
 
       [
         ModsDisplay::Values.new(
           label: I18n.t('mods_display.extent'),
-          values: extent_fields.map { |x| element_text(x) }
+          values: extent_elements.map { |x| element_text(x) }
         )
       ]
     end
 
     private
 
-    def extent_fields
-      @values.map(&:extent).flatten
+    def extent_elements
+      @stanford_mods_elements.map(&:extent).flatten
     end
   end
 end

--- a/lib/mods_display/fields/form.rb
+++ b/lib/mods_display/fields/form.rb
@@ -3,20 +3,20 @@
 module ModsDisplay
   class Form < Field
     def fields
-      return [] unless form_fields.present?
+      return [] unless form_elements.present?
 
       [
         ModsDisplay::Values.new(
           label: I18n.t('mods_display.form'),
-          values: form_fields.map { |x| element_text(x) }.uniq { |x| x.downcase.gsub(/\s/, '').gsub(/[[:punct:]]/, '') }
+          values: form_elements.map { |x| element_text(x) }.uniq { |x| x.downcase.gsub(/\s/, '').gsub(/[[:punct:]]/, '') }
         )
       ]
     end
 
     private
 
-    def form_fields
-      @values.map(&:form).flatten
+    def form_elements
+      @stanford_mods_elements.map(&:form).flatten
     end
   end
 end

--- a/lib/mods_display/fields/frequency.rb
+++ b/lib/mods_display/fields/frequency.rb
@@ -3,7 +3,7 @@
 module ModsDisplay
   class Frequency < Field
     def fields
-      return_fields = @values.map do |origin_info_element|
+      return_fields = @stanford_mods_elements.map do |origin_info_element|
         frequency_value = origin_info_element.frequency&.text&.strip
         next unless frequency_value.present?
 

--- a/lib/mods_display/fields/genre.rb
+++ b/lib/mods_display/fields/genre.rb
@@ -3,8 +3,11 @@
 module ModsDisplay
   class Genre < Field
     def fields
-      return_fields = @values.map do |value|
-        ModsDisplay::Values.new(label: displayLabel(value) || label, values: [element_text(value).capitalize].flatten)
+      return_fields = @stanford_mods_elements.map do |genre_element|
+        ModsDisplay::Values.new(
+          label: displayLabel(genre_element) || label,
+          values: [element_text(genre_element).capitalize].flatten
+        )
       end
       collapse_fields(return_fields)
     end

--- a/lib/mods_display/fields/geo.rb
+++ b/lib/mods_display/fields/geo.rb
@@ -25,8 +25,8 @@ module ModsDisplay
     end
 
     def geo_extensions
-      @geo_values ||= @values.select do |value|
-        displayLabel(value) =~ /^geo:?$/
+      @geo_values ||= @stanford_mods_elements.select do |extension_element|
+        displayLabel(extension_element) =~ /^geo:?$/
       end
     end
   end

--- a/lib/mods_display/fields/identifier.rb
+++ b/lib/mods_display/fields/identifier.rb
@@ -3,8 +3,11 @@
 module ModsDisplay
   class Identifier < Field
     def fields
-      return_fields = @values.map do |value|
-        ModsDisplay::Values.new(label: displayLabel(value) || identifier_label(value), values: [element_text(value)])
+      return_fields = @stanford_mods_elements.map do |identifier_element|
+        ModsDisplay::Values.new(
+          label: displayLabel(identifier_element) || identifier_label(identifier_element),
+          values: [element_text(identifier_element)]
+        )
       end
       collapse_fields(return_fields)
     end

--- a/lib/mods_display/fields/imprint.rb
+++ b/lib/mods_display/fields/imprint.rb
@@ -9,28 +9,28 @@ module ModsDisplay
     end
 
     def origin_info_data
-      @values.map do |value|
+      @stanford_mods_elements.map do |origin_info_element|
         return_fields = []
 
-        edition = edition_element(value)
-        place = place_element(value)
-        publisher = publisher_element(value)
-        parts = parts_element(value)
+        edition = edition_element(origin_info_element)
+        place = place_element(origin_info_element)
+        publisher = publisher_element(origin_info_element)
+        parts = parts_element(origin_info_element)
         place_pub = compact_and_join_with_delimiter([place, publisher], ' : ')
         edition_place = compact_and_join_with_delimiter([edition, place_pub], ' - ')
         joined_place_parts = compact_and_join_with_delimiter([edition_place, parts], ', ')
 
         unless joined_place_parts.empty?
           return_fields << ModsDisplay::Values.new(
-            label: displayLabel(value) || I18n.t('mods_display.imprint'),
+            label: displayLabel(origin_info_element) || I18n.t('mods_display.imprint'),
             values: [joined_place_parts]
           )
         end
-        return_fields.concat(date_values(value))
+        return_fields.concat(date_values(origin_info_element))
 
-        other_pub_info(value).each do |pub_info|
+        other_pub_info(origin_info_element).each do |pub_info|
           return_fields << ModsDisplay::Values.new(
-            label: displayLabel(value) || pub_info_labels[pub_info.name.to_sym],
+            label: displayLabel(origin_info_element) || pub_info_labels[pub_info.name.to_sym],
             values: [element_text(pub_info)]
           )
         end

--- a/lib/mods_display/fields/issuance.rb
+++ b/lib/mods_display/fields/issuance.rb
@@ -3,7 +3,7 @@
 module ModsDisplay
   class Issuance < Field
     def fields
-      return_fields = @values.map do |origin_info_element|
+      return_fields = @stanford_mods_elements.map do |origin_info_element|
         issuance_value = origin_info_element.issuance&.text&.strip
         next unless issuance_value.present?
 

--- a/lib/mods_display/fields/language.rb
+++ b/lib/mods_display/fields/language.rb
@@ -3,14 +3,14 @@
 module ModsDisplay
   class Language < Field
     def fields
-      return_fields = @values.map do |value|
-        next unless value.respond_to?(:languageTerm)
+      return_fields = @stanford_mods_elements.map do |language_element|
+        next unless language_element.respond_to?(:languageTerm)
 
-        value.languageTerm.map do |term|
+        language_element.languageTerm.map do |term|
           next unless term.attributes['type'].respond_to?(:value) && term.attributes['type'].value == 'code'
 
           ModsDisplay::Values.new(
-            label: displayLabel(value) || displayLabel(term) || I18n.t('mods_display.language'),
+            label: displayLabel(language_element) || displayLabel(term) || I18n.t('mods_display.language'),
             values: [language_codes[element_text(term)]]
           )
         end.flatten.compact

--- a/lib/mods_display/fields/location.rb
+++ b/lib/mods_display/fields/location.rb
@@ -4,20 +4,20 @@ module ModsDisplay
   class Location < Field
     def fields
       return_fields = []
-      @values.each do |location|
-        location.children.each do |child|
+      @stanford_mods_elements.each do |location_element|
+        location_element.children.each do |child|
           next unless location_field_keys.include?(child.name.to_sym)
 
           if child.name.to_sym == :url
-            loc_label = displayLabel(location) || I18n.t('mods_display.location')
+            loc_label = displayLabel(location_element) || I18n.t('mods_display.location')
             value = "<a href='#{element_text(child)}'>#{(displayLabel(child) || element_text(child)).gsub(/:$/,
                                                                                                           '')}</a>"
           else
-            loc_label = location_label(child) || displayLabel(location) || I18n.t('mods_display.location')
+            loc_label = location_label(child) || displayLabel(location_element) || I18n.t('mods_display.location')
             value = element_text(child)
           end
           return_fields << ModsDisplay::Values.new(
-            label: loc_label || displayLabel(location) || I18n.t('mods_display.location'),
+            label: loc_label || displayLabel(location_element) || I18n.t('mods_display.location'),
             values: [value]
           )
         end

--- a/lib/mods_display/fields/name.rb
+++ b/lib/mods_display/fields/name.rb
@@ -4,15 +4,16 @@ module ModsDisplay
   class Name < Field
     include ModsDisplay::RelatorCodes
 
-    # this returns a hash:
-    #  { role1 label => [ ModsDisplay:Name:Person,  ModsDisplay:Name:Person, ...], role2 label => [ ModsDisplay:Name:Person,  ModsDisplay:Name:Person, ...] }
+    # returns a hash:
+    #  { role1 label => [ ModsDisplay:Name:Person,  ModsDisplay:Name:Person, ...],
+    #    role2 label => [ ModsDisplay:Name:Person,  ModsDisplay:Name:Person, ...] }
     def fields
-      return_fields = @values.map do |value|
-        name_parts = ModsDisplay::NameFormatter.format(value)
-        person = name_parts ? ModsDisplay::Name::Person.new(name: name_parts, name_identifiers: value.xpath('mods:nameIdentifier', mods: MODS_NS)) : nil
+      return_fields = @stanford_mods_elements.map do |plain_name_element|
+        name_parts = ModsDisplay::NameFormatter.format(plain_name_element)
+        person = name_parts ? ModsDisplay::Name::Person.new(name: name_parts, name_identifiers: plain_name_element.xpath('mods:nameIdentifier', mods: MODS_NS)) : nil
         # The person may have multiple roles, so we have to divide them up into an array
-        role_labels(value).collect do |role_label|
-          ModsDisplay::Values.new(label: displayLabel(value) || role_label, values: [person]) if person
+        role_labels(plain_name_element).collect do |role_label|
+          ModsDisplay::Values.new(label: displayLabel(plain_name_element) || role_label, values: [person]) if person
         end
       end.flatten.compact
       collapse_roles(collapse_fields(return_fields))

--- a/lib/mods_display/fields/nested_related_item.rb
+++ b/lib/mods_display/fields/nested_related_item.rb
@@ -15,14 +15,14 @@ module ModsDisplay
 
     def fields
       @fields ||= begin
-        return_fields = RelatedItemValue.for_values(@values).map do |value|
-          next if value.collection?
-          next unless render_nested_related_item?(value)
+        return_fields = RelatedItemValue.for_values(@stanford_mods_elements).map do |related_item_element|
+          next if related_item_element.collection?
+          next unless render_nested_related_item?(related_item_element)
 
-          related_item_text = @value_renderer.new(value).render
+          related_item_text = @value_renderer.new(related_item_element).render
 
           ModsDisplay::Values.new(
-            label: related_item_label(value),
+            label: related_item_label(related_item_element),
             values: [related_item_text]
           )
         end.compact
@@ -30,9 +30,10 @@ module ModsDisplay
       end
     end
 
+    # this class provides html markup and is subclassed in purl application
     class ValueRenderer
-      def initialize(value)
-        @value = value
+      def initialize(related_item_element)
+        @related_item_element = related_item_element
       end
 
       def render
@@ -41,7 +42,7 @@ module ModsDisplay
 
       protected
 
-      attr_reader :value
+      attr_reader :related_item_element
 
       def mods_display_html
         @mods_display_html ||= ModsDisplay::HTML.new(mods)
@@ -50,7 +51,7 @@ module ModsDisplay
       def mods
         @mods ||= ::Stanford::Mods::Record.new.tap do |r|
           # dup'ing the value adds the appropriate namespaces, but...
-          munged_node = value.dup.tap do |x|
+          munged_node = related_item_element.dup.tap do |x|
             # ... the mods gem also expects the root of the document to have the root tag <mods>
             x.name = 'mods'
           end
@@ -68,9 +69,9 @@ module ModsDisplay
 
     private
 
-    def related_item_label(item)
-      return displayLabel(item) if displayLabel(item)
-      return I18n.t('mods_display.constituent') if item.constituent?
+    def related_item_label(related_item_element)
+      return displayLabel(related_item_element) if displayLabel(related_item_element)
+      return I18n.t('mods_display.constituent') if related_item_element.constituent?
 
       I18n.t('mods_display.host')
     end

--- a/lib/mods_display/fields/note.rb
+++ b/lib/mods_display/fields/note.rb
@@ -3,9 +3,12 @@
 module ModsDisplay
   class Note < Field
     def fields
-      return_fields = note_fields.map do |value|
-        ModsDisplay::Values.new(label: displayLabel(value) || note_label(value), values: [element_text(value)],
-                                field: self)
+      return_fields = note_fields.map do |note_element|
+        ModsDisplay::Values.new(
+          label: displayLabel(note_element) || note_label(note_element),
+          values: [element_text(note_element)],
+          field: self
+        )
       end
       collapse_fields(return_fields)
     end
@@ -17,10 +20,10 @@ module ModsDisplay
     end
 
     def note_fields
-      @values.select do |value|
-        !value.attributes['type'].respond_to?(:value) ||
-          (value.attributes['type'].respond_to?(:value) &&
-             value.attributes['type'].value.downcase != 'contact')
+      @stanford_mods_elements.select do |note_element|
+        !note_element.attributes['type'].respond_to?(:value) ||
+          (note_element.attributes['type'].respond_to?(:value) &&
+             note_element.attributes['type'].value.downcase != 'contact')
       end
     end
 

--- a/lib/mods_display/fields/place.rb
+++ b/lib/mods_display/fields/place.rb
@@ -5,8 +5,8 @@ module ModsDisplay
     include ModsDisplay::CountryCodes
 
     def fields
-      return_fields = @values.map do |value|
-        place_value = place_element(value)
+      return_fields = @stanford_mods_elements.map do |origin_info_element|
+        place_value = place_element(origin_info_element)
         next unless place_value.present?
 
         ModsDisplay::Values.new(
@@ -21,10 +21,10 @@ module ModsDisplay
     private
 
     # not an exact duplicate of the method in Imprint, particularly trailing punctuation code
-    def place_element(value)
-      return if value.place.text.strip.empty?
+    def place_element(origin_info_element)
+      return if origin_info_element.place.text.strip.empty?
 
-      places = ModsDisplay::Imprint.new(value).place_terms(value).filter_map { |p| p.text unless p.text.strip.empty? }
+      places = ModsDisplay::Imprint.new(origin_info_element).place_terms(origin_info_element).filter_map { |p| p.text unless p.text.strip.empty? }
       compact_and_remove_trailing_delimiter(places, ':').join
     end
 

--- a/lib/mods_display/fields/publisher.rb
+++ b/lib/mods_display/fields/publisher.rb
@@ -3,8 +3,8 @@
 module ModsDisplay
   class Publisher < Field
     def fields
-      return_fields = @values.map do |value|
-        publisher_value = Stanford::Mods::Imprint.new(value).publisher_vals_str
+      return_fields = @stanford_mods_elements.map do |origin_info_element|
+        publisher_value = Stanford::Mods::Imprint.new(origin_info_element).publisher_vals_str
         next unless publisher_value.present?
 
         publisher_value.gsub!(/ *,$/, '')

--- a/lib/mods_display/fields/related_item.rb
+++ b/lib/mods_display/fields/related_item.rb
@@ -10,33 +10,37 @@ module ModsDisplay
     end
 
     def fields
-      return_fields = RelatedItemValue.for_values(@values).map do |value|
-        next if value.collection?
-        next if render_nested_related_item?(value)
+      return_fields = RelatedItemValue.for_values(@stanford_mods_elements).map do |related_item_element|
+        next if related_item_element.collection?
+        next if render_nested_related_item?(related_item_element)
 
-        text = @value_renderer.new(value).render
-
+        text = @value_renderer.new(related_item_element).render
         next if text.nil? || text.empty?
 
-        ModsDisplay::Values.new(label: related_item_label(value), values: [text])
+        ModsDisplay::Values.new(
+          label: related_item_label(related_item_element),
+          values: [text]
+        )
       end.compact
       collapse_fields(return_fields)
     end
 
+    # this class provides html markup and is mimicking the same class
+    #   in NestedRelatedItem (which is subclassed in purl application)
     class ValueRenderer
-      def initialize(value)
-        @value = value
+      def initialize(related_item_element)
+        @related_item_element = related_item_element
       end
 
       def render
-        if value.location?
-          element_text(value.location_nodeset)
-        elsif value.reference?
-          reference_title(value)
-        elsif value.titleInfo_nodeset.any?
-          title = element_text(value.titleInfo_nodeset)
+        if related_item_element.location?
+          element_text(related_item_element.location_nodeset)
+        elsif related_item_element.reference?
+          reference_title(related_item_element)
+        elsif related_item_element.titleInfo_nodeset.any?
+          title = element_text(related_item_element.titleInfo_nodeset)
           location = nil
-          location = element_text(value.location_url_nodeset) if value.location_url_nodeset.length.positive?
+          location = element_text(related_item_element.location_url_nodeset) if related_item_element.location_url_nodeset.length.positive?
 
           return if title.empty?
 
@@ -45,8 +49,8 @@ module ModsDisplay
           else
             title
           end
-        elsif value.note_nodeset.any?
-          citation = value.note_nodeset.find { |note| note['type'] == 'preferred citation' }
+        elsif related_item_element.note_nodeset.any?
+          citation = related_item_element.note_nodeset.find { |note| note['type'] == 'preferred citation' }
 
           element_text(citation) if citation
         end
@@ -54,36 +58,30 @@ module ModsDisplay
 
       protected
 
-      attr_reader :value
+      attr_reader :related_item_element
 
       def element_text(element)
         element.xpath('.//text()').to_html.strip
       end
 
-      def reference_title(item)
-        [item.titleInfo_nodeset,
-         item.originInfo.dateOther,
-         item.part.detail.number,
-         item.note_nodeset].flatten.compact.map!(&:text).map!(&:strip).join(' ')
+      def reference_title(related_item_element)
+        [related_item_element.titleInfo_nodeset,
+         related_item_element.originInfo.dateOther,
+         related_item_element.part.detail.number,
+         related_item_element.note_nodeset].flatten.compact.map!(&:text).map!(&:strip).join(' ')
       end
     end
 
     private
 
-    attr_reader :value_renderer
-
-    def delimiter
-      '<br />'.html_safe
-    end
-
-    def related_item_label(item)
-      if displayLabel(item)
-        displayLabel(item)
+    def related_item_label(related_item_element)
+      if displayLabel(related_item_element)
+        displayLabel(related_item_element)
       else
         case
-        when item.location?
+        when related_item_element.location?
           return I18n.t('mods_display.location')
-        when item.reference?
+        when related_item_element.reference?
           return I18n.t('mods_display.referenced_by')
         end
         I18n.t('mods_display.related_item')

--- a/lib/mods_display/fields/resource_type.rb
+++ b/lib/mods_display/fields/resource_type.rb
@@ -3,16 +3,19 @@
 module ModsDisplay
   class ResourceType < Field
     def fields
-      return_fields = @values.map do |value|
-        ModsDisplay::Values.new(label: displayLabel(value) || label, values: [element_text(value)])
+      return_fields = @stanford_mods_elements.map do |type_of_resource_element|
+        ModsDisplay::Values.new(
+          label: displayLabel(type_of_resource_element) || label,
+          values: [element_text(type_of_resource_element)]
+        )
       end
       collapse_fields(return_fields)
     end
 
     private
 
-    def displayLabel(element)
-      super(element) || I18n.t('mods_display.type_of_resource')
+    def displayLabel(type_of_resource_element)
+      super(type_of_resource_element) || I18n.t('mods_display.type_of_resource')
     end
   end
 end

--- a/lib/mods_display/fields/subject.rb
+++ b/lib/mods_display/fields/subject.rb
@@ -4,11 +4,11 @@ module ModsDisplay
   class Subject < Field
     def fields
       return_fields = []
-      @values.each do |value|
+      @stanford_mods_elements.each do |subject_element|
         return_values = []
-        label = displayLabel(value) || I18n.t('mods_display.subject')
+        label = displayLabel(subject_element) || I18n.t('mods_display.subject')
         return_text = []
-        selected_subjects(value).each do |child|
+        selected_subjects(subject_element).each do |child|
           if respond_to?(:"process_#{child.name}")
             method_send = send(:"process_#{child.name}", child)
             return_text << method_send unless method_send.to_s.empty?

--- a/lib/mods_display/fields/title.rb
+++ b/lib/mods_display/fields/title.rb
@@ -8,10 +8,10 @@ module ModsDisplay
     end
 
     def fields
-      return_values = sorted_values.map do |value|
+      return_values = sorted_title_info_elements.map do |title_info_element|
         ModsDisplay::Values.new(
-          label: displayLabel(value) || title_label(value),
-          values: [assemble_title(value)]
+          label: displayLabel(title_info_element) || title_label(title_info_element),
+          values: [assemble_title(title_info_element)]
         )
       end
       collapse_fields(return_values)
@@ -20,50 +20,50 @@ module ModsDisplay
     private
 
     # If there is a node with usage="primary", then it should come first.
-    def sorted_values
-      Array(@values).sort_by { |node| node['usage'] == 'primary' ? 0 : 1 }
+    def sorted_title_info_elements
+      Array(@stanford_mods_elements).sort_by { |title_info_element| title_info_element['usage'] == 'primary' ? 0 : 1 }
     end
 
     def delimiter
       '<br />'.html_safe
     end
 
-    def assemble_title(element)
+    def assemble_title(title_info_element)
       title = ''
       previous_element = nil
 
-      element.children.select { |value| title_parts.include? value.name }.each do |value|
-        str = value.text.strip
-        next if str.empty?
+      title_info_element.children.select { |child| title_parts.include? child.name }.each do |child|
+        text = child.text.strip
+        next if text.empty?
 
-        delimiter = title_delimiter(title, previous_element, value)
+        delimiter = title_delimiter(title, previous_element, child)
 
         title += delimiter if delimiter
-        title += str
+        title += text
 
-        previous_element = value
+        previous_element = child
       end
 
-      full_title = if element['type'] == 'uniform' && element['nameTitleGroup'].present?
-                     [uniform_title_name_part(element), title].compact.join('. ')
+      full_title = if title_info_element['type'] == 'uniform' && title_info_element['nameTitleGroup'].present?
+                     [uniform_title_name_part(title_info_element), title].compact.join('. ')
                    else
                      title
                    end
       linked_title(full_title)
     end
 
-    def title_delimiter(title, previous_element, value)
+    def title_delimiter(title, previous_element, child)
       if title.empty? || title.end_with?(' ')
         nil
       elsif previous_element&.name == 'nonSort' && title.end_with?('-', '\'')
         nil
       elsif title.end_with?('.', ',', ':', ';')
         ' '
-      elsif value.name == 'subTitle'
+      elsif child.name == 'subTitle'
         ' : '
-      elsif value.name == 'partName' && previous_element.name == 'partNumber'
+      elsif child.name == 'partName' && previous_element.name == 'partNumber'
         ', '
-      elsif value.name == 'partNumber' || value.name == 'partName'
+      elsif child.name == 'partNumber' || child.name == 'partName'
         '. '
       else
         ' '

--- a/lib/mods_display/fields/values.rb
+++ b/lib/mods_display/fields/values.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 module ModsDisplay
+  # This class has what is needed by view code in downstream applications
   class Values
     attr_accessor :label, :values, :field
 


### PR DESCRIPTION
closes #164

looks big, but the changes are very simple.

Addresses:
- how does Field @values get populated? (answered with comment) <-- this is a key part of this gem
- what are the objects that are @values?  (answered with better variable name) <-- this is also a key part of this gem
- is there a difference between Field @values and ModsDisplay::Values @values? (answered with better variable name and class comment for ModsDisplay::Values)
